### PR TITLE
[Athena] Architecture overview + multiplayer MVP milestone plan

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,129 @@
+# Pluton Poker — Current Architecture Overview
+
+## High-level snapshot
+
+This project already has two important pillars in place:
+1. **Core local Texas Hold'em game loop** (state machine + betting + hand evaluation)
+2. **Photon lobby/room scaffolding** (connect, room list, player list, ready/start flow)
+
+What it does **not** yet have is a full authoritative multiplayer gameplay layer that synchronizes actual hand state and actions across clients.
+
+---
+
+## Runtime architecture
+
+## 1) Core game domain (local simulation)
+
+### Entry point: `PokerStateMachine`
+- File: `Assets/Scripts/Poker/PokerStateMachine.cs`
+- Responsibilities:
+  - Initializes players, deck, betting manager, and game states
+  - Owns player list and in-round action queue
+  - Creates/tears down hand/river visuals
+  - Transitions state machine stages for each round
+
+### State machine flow
+- `GameStateRoundStart` -> `GameStateDeal` -> `GameStateBetting` -> `GameStateRoundEnd`
+- File group: `Assets/Scripts/Poker/GameState*.cs`
+
+Round lifecycle today:
+1. Build fresh deck + queue active players
+2. Deal private cards / flop / turn / river in phases
+3. Run betting cycle between deal phases
+4. Evaluate winner and award pot
+5. Restart round manually via UI
+
+### Betting + turns
+- `BettingManager` owns:
+  - pot
+  - blind amounts
+  - blind rotation logic
+- `GameStateBetting` owns:
+  - whose turn it is
+  - highest bet tracking
+  - transition rules to next state
+
+### Player model
+- `PokerPlayer` is currently a pure C# data object:
+  - money
+  - hand
+  - current bet
+  - folded state
+  - event callback for action submission
+
+### Hand evaluation
+- `PlayerHand` + `GenHand` evaluate best combination from 7 cards.
+- This appears mostly implemented, but there are likely correctness edge cases (see risks section).
+
+---
+
+## 2) Visual/UI layer
+
+- `PlayerObject`, `RiverObject`, `CardObject` create and render card visuals.
+- UI scripts (`UI_*`) subscribe to state events and render simple status:
+  - round end winner text
+  - blind indicators
+  - pot text
+  - per-player money/name indicators
+
+This is a straightforward adapter layer from gameplay state to scene objects.
+
+---
+
+## 3) Networking layer (Photon)
+
+### Current capabilities
+- Connect to Photon (`TestConnect`)
+- Create/join room (`CreateRoomMenu`, `RoomListing`, `RoomListingsMenu`)
+- Show players in room (`PlayerListingsMenu`)
+- Ready/start gate in room
+- Master client can load gameplay scene
+
+### Current limitation
+Gameplay itself is not yet truly network-authoritative:
+- No synchronized deck seed/deal stream
+- No authoritative turn executor
+- No robust action replication/validation per player
+- No deterministic reconciliation for disconnect/rejoin
+
+So multiplayer plumbing exists in lobby UX, but the **actual poker round simulation is still effectively local**.
+
+---
+
+## Scene / system split (inferred)
+
+- **Lobby scene**: Photon connection + room list + room UI
+- **Game scene**: local poker simulation and table UI
+
+`PhotonNetwork.AutomaticallySyncScene = true` is enabled, so master-driven scene loading is already wired.
+
+---
+
+## Key technical risks observed
+
+1. **Potential hand-evaluation correctness bugs**
+   - Example: flush detection checks `== 5` suit count (not `>= 5`), which can miss 6/7-card flush scenarios.
+   - Example: straight detection window loop likely misses one valid starting window.
+   - Example: `FourOfKind()` appears to add hand as `ThreeKind` (likely typo bug).
+
+2. **No authoritative multiplayer game state owner**
+   - Any client-side mismatch can desync bets/pot/winner.
+
+3. **Local data model not mapped to Photon actor IDs**
+   - `PokerPlayer` currently index-based (`PlayerID`) and local-first.
+
+4. **No recovery model for disconnect/rejoin during a hand**
+
+5. **No side-pot/all-in logic yet**
+   - Current bet model seems geared to simple call/raise/fold loop.
+
+---
+
+## What is in good shape already
+
+- Clean conceptual state machine layout (great foundation)
+- Clear betting phase boundaries
+- Working room/lobby shell in Photon
+- Reusable table/card prefab architecture
+
+This is a very good MVP base — it mainly needs correctness hardening and a server-authoritative multiplayer pass.

--- a/docs/multiplayer-mvp-milestones.md
+++ b/docs/multiplayer-mvp-milestones.md
@@ -1,0 +1,158 @@
+# Pluton Poker — Multiplayer MVP Milestone Plan
+
+Goal: ship a **playable, stable online Texas Hold'em MVP** (private rooms, 2–6 players, one table, no economy backend).
+
+## MVP scope (explicit)
+
+### In scope
+- Create/join private room
+- Sit players in fixed seats
+- Start hand when room is ready
+- Authoritative dealing/turns/bets/winner
+- Fold/call/check/raise actions
+- Pot payout to winner
+- Basic reconnect handling (same room, mid-hand snapshot restore)
+
+### Out of scope (post-MVP)
+- Matchmaking/ranked
+- Tournaments
+- Cosmetics/store
+- Full side-pot complexity (can be added in v2)
+- Anti-cheat hardening beyond basic server authority
+
+---
+
+## Milestone 0 — Code Health + Rule Correctness (must do first)
+
+Purpose: avoid building networking on top of broken hand logic.
+
+Tasks:
+- Add deterministic test coverage for hand evaluator (`PlayerHand`)
+  - royal flush, straight flush, quads, full house, flush(6/7 cards), wheel straight, tie breakers
+- Fix known likely bugs:
+  - flush `== 5` -> `>= 5`
+  - straight window iteration bounds
+  - `FourOfKind` hand-tag typo
+  - any pair/full-house edge-case index errors found by tests
+- Add a tiny debug test harness to run scripted hands quickly in-editor
+
+Done when:
+- Hand-ranking tests pass with stable expected outcomes.
+
+---
+
+## Milestone 1 — Authoritative Multiplayer Game Core
+
+Purpose: make one source of truth for game state.
+
+Tasks:
+- Define a serializable `PokerGameSnapshot`:
+  - phase, dealer/blinds, current turn actor, pot, highest bet
+  - player chips/current bet/folded/all-in
+  - community cards + masked hole card ownership
+- Introduce network authority model:
+  - Master client acts as temporary authority for MVP (or Photon room owner logic)
+  - only authority mutates round state
+- Convert player identity from local index to Photon ActorNumber mapping
+- Broadcast state deltas via RPC/Event code
+
+Done when:
+- Non-authority clients are pure viewers/inputs; authority resolves state.
+
+---
+
+## Milestone 2 — Turn + Action Replication
+
+Purpose: make betting rounds reliable online.
+
+Tasks:
+- Action command pipeline (`Fold`, `Check`, `Call`, `Raise(amount)`)
+  - client sends request
+  - authority validates + applies
+  - authority broadcasts accepted action + new snapshot
+- Enforce turn timeout behavior (basic auto-fold for MVP)
+- Prevent out-of-turn input on all clients
+- Keep UI in sync with authority snapshot after every action
+
+Done when:
+- 2+ clients can complete full preflop/flop/turn/river action loops without desync.
+
+---
+
+## Milestone 3 — Deal/Reveal Sync + Winner Resolution
+
+Purpose: ensure every client sees consistent cards and outcomes.
+
+Tasks:
+- Authority-generated shuffled deck seed/order
+- Deterministic dealing events for hole cards/community cards
+- Hide opponent hole cards until showdown unless folded reveal is desired
+- Authority computes winner and payout, then publishes final hand result payload
+
+Done when:
+- All clients agree on same board, same winner, same chip totals.
+
+---
+
+## Milestone 4 — Room-to-Table UX Glue
+
+Purpose: get an actual playable loop from lobby to repeated hands.
+
+Tasks:
+- Seat assignment and display names on table UI
+- Ready/start checks in room tied to game start conditions
+- End-of-hand -> next hand transition
+- Add minimal in-game status text:
+  - whose turn
+  - call amount
+  - pot
+  - last action
+
+Done when:
+- Friends can create room, start game, and play multiple hands smoothly.
+
+---
+
+## Milestone 5 — Resilience Pass (MVP hardening)
+
+Purpose: avoid rage-quit bugs and stuck matches.
+
+Tasks:
+- Rejoin same room restore:
+  - on rejoin, authority sends latest snapshot
+- Master client migration fallback:
+  - if authority leaves, pause hand + elect new authority + recover snapshot
+- Guard rails:
+  - no stuck turn states
+  - no negative chip bugs
+  - no phantom duplicated actions
+
+Done when:
+- Basic disconnect/reconnect paths recover without killing session.
+
+---
+
+## Immediate next 10 tasks (small-bite execution)
+
+1. Create `docs/rules-test-cases.md` with 20 canonical hand scenarios.
+2. Add unit-test scaffold for hand eval (EditMode tests).
+3. Fix + verify flush detection for 6/7 suited cards.
+4. Fix + verify straight window scanning bounds.
+5. Fix quads hand labeling bug.
+6. Define `PokerGameSnapshot` C# model.
+7. Add Photon actor-to-seat mapping model.
+8. Add authority-only state mutation gate in game manager.
+9. Add one action RPC (`Fold`) end-to-end as spike.
+10. Add snapshot broadcast + UI refresh after action.
+
+---
+
+## Recommended order for you right now
+
+If you want fastest path to confidence:
+1. **Milestone 0 first** (rule correctness)
+2. Then **Milestone 1 + 2** (authoritative loop)
+3. Then **Milestone 3** (deal/reveal/winner sync)
+4. Then UX/resilience polish
+
+That sequence gives you a playable multiplayer poker MVP without pretending the hard parts are solved.


### PR DESCRIPTION
## Summary
- add architecture overview of current Pluton Poker runtime systems
- document current strengths, networking gaps, and technical risk areas
- define milestone roadmap to reach a playable multiplayer poker MVP
- include immediate next small-bite tasks for execution

## Files
- docs/architecture-overview.md
- docs/multiplayer-mvp-milestones.md

## Notes
This PR is documentation/planning only and intentionally does not change gameplay runtime code yet.