### PR TITLE
[Athena] Milestone 0 rule correctness

### DIFF
--- a/Assets/Scripts/Poker/PlayerHand.cs
+++ b/Assets/Scripts/Poker/PlayerHand.cs
@@ -35,9 +35,12 @@ public class PlayerHand : GenHand
     public Hand EvaluateHand(GenHand RiverHand)
     {
         Hand currHand = Hand.NULL;
-        //cardHand = new List<Card>();
 
         cardHand.Clear();
+        sortedValueHand.Clear();
+        sortedFlushHand.Clear();
+        suitDict.Clear();
+        valueDict.Clear();
         potentialHandList.Clear();
 
         foreach (Card c in RiverHand.CardHand)
@@ -60,20 +63,13 @@ public class PlayerHand : GenHand
 
         SetHighCard(ref currHand);
 
-        //get the number of each suit on hand
         GetNumberOfAllSuits();
-
-        //get the number of each value on hand
         GetNumberOfAllValues();
 
         SetPairs(ref currHand);
-
         SetFlush(ref currHand);
-
         SetStraight(ref currHand);
-
         SetStraightFlush(ref currHand);
-
         SetRoyalFlush(ref currHand);
 
         finalHandInfo = GetHighestPotentialHand(currHand);
@@ -105,7 +101,6 @@ public class PlayerHand : GenHand
                 }
                 else if (highestHandInfo.HighCard == listHands[i].HighCard)
                 {
-                    //umm tie but fuck it?
                     highestHandInfo = listHands[i];
                 }
             }            
@@ -144,60 +139,57 @@ public class PlayerHand : GenHand
     {
         foreach (SUIT s in suitDict.Keys)
         {
-            if (suitDict[s] == 5)
+            if (suitDict[s] >= 5)
             {
                 if (currHand < Hand.Flush)
                 {
                     currHand = Hand.Flush;
                 }
-                Flush();
+                Flush(s);
             }
         }
     }
 
     protected void SetStraight(ref Hand currHand)
     {
-        //So if we are checking a straight with 7 cards
-        //We essentially just need to go through the first 3
-        for (int i = 0; i+5 < sortedValueHand.Count; i++)
+        List<int> distinctValues = sortedValueHand
+            .Select(card => (int)card.MyValue)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToList();
+
+        if (distinctValues.Contains((int)VALUE.VA))
+        {
+            distinctValues.Insert(0, 1);
+        }
+
+        for (int i = 0; i <= distinctValues.Count - 5; i++)
         {
             bool isStraight = true;
-            int initCheck = 0;
-            //Lets go through 5 cards with the starting index
-            for (int j = i; j < i+5; j++ )
+            for (int j = 1; j < 5; j++)
             {
-                int currValue = (int)sortedValueHand[j].MyValue;
-                if (j == 0)
-                {
-                    initCheck = currValue;
-                }
-                else if (currValue != initCheck + 1)
+                if (distinctValues[i + j] != distinctValues[i] + j)
                 {
                     isStraight = false;
+                    break;
                 }
-                else
-                {
-                    initCheck = currValue;
-                }
+            }
 
-                //If we are at the very last index of this straight check
-                //And if isStraight was never interrupted
-                if (j == i+4 && isStraight)
-                {
-                    int firstIndex = i;
-                    int lastIndex = j;
-                    int total = (int)sortedValueHand[j].MyValue;
-                    int highCard = (int)sortedValueHand[j].MyValue;
+            if (!isStraight)
+            {
+                continue;
+            }
 
-                    int[] cardIndexes = Get5CardIndexesInOrder(firstIndex);
+            List<int> straightValues = distinctValues.Skip(i).Take(5).ToList();
+            int[] cardIndexes = GetCardIndexesForValues(straightValues);
+            int highCard = straightValues.Last() == 1 ? 5 : straightValues.Last();
+            int total = highCard;
 
-                    potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.Straight, total, highCard));
+            potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.Straight, total, highCard));
 
-                    if (currHand < Hand.Straight)
-                    {
-                        currHand = Hand.Straight;
-                    }
-                }
+            if (currHand < Hand.Straight)
+            {
+                currHand = Hand.Straight;
             }
         }
     }
@@ -370,45 +362,38 @@ public class PlayerHand : GenHand
         int[] cardIndexes = new int[5];
         int highCard = 0;
         int index = 0;
-        for (int i = 0; i < sortedValueHand.Count - 1; i++)
+        for (int i = 0; i < sortedValueHand.Count - 3; i++)
         {
-
-            if (i + 3 < sortedValueHand.Count)
+            if (sortedValueHand[i].MyValue == sortedValueHand[i + 3].MyValue)
             {
-                //Do we have a 3 of a kind
-                if (sortedValueHand[i].MyValue == sortedValueHand[i + 3].MyValue)
+                cardIndexes[index++] = i;
+                cardIndexes[index++] = i + 1;
+                cardIndexes[index++] = i + 2;
+                cardIndexes[index++] = i + 3;
+
+                int kickerIndex = -1;
+                for (int j = sortedValueHand.Count - 1; j >= 0; j--)
                 {
-                    //Put the pair in the card indexes
-                    cardIndexes[index] = i;
-                    index++;
-                    cardIndexes[index] = i + 1;
-                    index++;
-                    cardIndexes[index] = i + 2;
-                    index++;
-                    cardIndexes[index] = i + 3;
-                    index++;
-
-                    //Lets get the highest card
-                    if (i + 2 == sortedValueHand.Count - 1)
+                    if (j < i || j > i + 3)
                     {
-                        highCard = (int)sortedValueHand[i - 1].MyValue;
-                        cardIndexes[index] = i - 1;
+                        kickerIndex = j;
+                        break;
                     }
-                    else
-                    {
-                        highCard = (int)sortedValueHand[sortedValueHand.Count - 1].MyValue;
-                        cardIndexes[sortedValueHand.Count - 1] = i - 1;
-                    }
-
-                    break;
                 }
+
+                if (kickerIndex >= 0)
+                {
+                    cardIndexes[index] = kickerIndex;
+                    highCard = (int)sortedValueHand[kickerIndex].MyValue;
+                }
+
+                break;
             }
         }
 
-
         int total = (int)sortedValueHand[cardIndexes[0]].MyValue * 4;
 
-        potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.ThreeKind, total, highCard));
+        potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.FourKind, total, highCard));
     }
 
     protected void FullHouse()
@@ -418,9 +403,6 @@ public class PlayerHand : GenHand
         int index = 0;
         int total = 0;
 
-        //Lets go through all the cards from the top
-        //This way if we have 2 pairs and a 3 of a kind
-        //It'll automatically grab the highest pair
         for (int i = sortedValueHand.Count - 1; i >= 0 ; i--)
         {
             if (index > 4)
@@ -442,14 +424,11 @@ public class PlayerHand : GenHand
                     cardIndexes[index] = i - 2;
                     index++;
 
-                    //Increment past the 3
                     i -= 2;
                 }
             }
             else if (i - 1 >= 0)
             {
-                //We need to check if we have already found the first pair
-                //If we have then we have to ignore second by checking the index doesn't equal 2
                 if (sortedValueHand[i] == sortedValueHand[i - 1] && index != 2)
                 {
                     total += (int)sortedValueHand[i].MyValue * 2;
@@ -459,7 +438,6 @@ public class PlayerHand : GenHand
                     cardIndexes[index] = i - 1;
                     index++;
 
-                    //Increment past the pair
                     i--;
                 }
             }
@@ -468,33 +446,30 @@ public class PlayerHand : GenHand
         potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.FullHouse, total, highCard));
     }
 
-    protected void Flush()
+    protected void Flush(SUIT suit)
     {
-        int firstIndex = 0;
+        List<int> suitedIndexes = new List<int>();
 
-        for (int i = 0; i+5 < sortedFlushHand.Count; i++)
+        for (int i = 0; i < sortedValueHand.Count; i++)
         {
-            if (sortedFlushHand[i].MySuit == sortedFlushHand[i+5].MySuit)
+            if (sortedValueHand[i].MySuit == suit)
             {
-                if (firstIndex < i) firstIndex = 0;
+                suitedIndexes.Add(i);
             }
         }
 
-        int lastIndex = firstIndex + 4;
-        int total = 0;
-        int highCard = 0;
+        suitedIndexes = suitedIndexes
+            .OrderBy(index => sortedValueHand[index].MyValue)
+            .ToList();
 
-        for (int i = sortedValueHand.Count - 1; i > -1; i--)
+        if (suitedIndexes.Count < 5)
         {
-            if(SortedValueHand[i].MySuit == sortedFlushHand[firstIndex].MySuit)
-            {
-                total = (int)SortedValueHand[i].MyValue;
-                highCard = (int)SortedValueHand[i].MyValue;
-                break;
-            }
+            return;
         }
 
-        int[] cardIndexes = Get5CardIndexesInOrder(firstIndex);
+        int[] cardIndexes = suitedIndexes.Skip(suitedIndexes.Count - 5).ToArray();
+        int highCard = (int)sortedValueHand[cardIndexes[cardIndexes.Length - 1]].MyValue;
+        int total = highCard;
 
         potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.Flush, total, highCard));
     }
@@ -506,12 +481,8 @@ public class PlayerHand : GenHand
         int index = 0;
         for (int i = 0; i < sortedValueHand.Count - 1; i++)
         {
-            //If we have already found the 3 of a kind
             if (index > 2 && index < 5)
             {
-                //lets add the higher cards
-                //if we add 2 and we are not at the end
-                //then we are at the lower end of the cards and we shoudln't add em
                 if (i + 2 >= sortedValueHand.Count)
                 {
                     cardIndexes[index] = i;
@@ -520,10 +491,8 @@ public class PlayerHand : GenHand
             }
             if (i + 2 < sortedValueHand.Count)
             {
-                //Do we have a 3 of a kind
                 if (sortedValueHand[i].MyValue == sortedValueHand[i + 2].MyValue)
                 {
-                    //Put the pair in the card indexes
                     cardIndexes[index] = i;
                     index++;
                     cardIndexes[index] = i + 1;
@@ -531,8 +500,6 @@ public class PlayerHand : GenHand
                     cardIndexes[index] = i + 2;
                     index++;
 
-
-                    //Lets get the highest card
                     if (i + 2 == sortedValueHand.Count - 1)
                     {
                         highCard = (int)sortedValueHand[i - 1].MyValue;
@@ -542,15 +509,11 @@ public class PlayerHand : GenHand
                         highCard = (int)sortedValueHand[sortedValueHand.Count - 1].MyValue;
                     }
 
-                    //Increment past the three with i
                     i += 2;
                 }
             }            
         }
 
-        //If we still haven't filled up the card indexes
-        //Lets go down from the start of the three of a kind
-        //And add cards until it's filled up
         int j = 1;
         while (index < 5)
         {
@@ -572,21 +535,16 @@ public class PlayerHand : GenHand
         int highCardIndex = -1;
         for (int i = sortedValueHand.Count - 1; i > -1; i--)
         {
-            //Check if we aren't out of bounds
             if (i-1 >= 0)
             {
-                //If the two are a pair
                 if (sortedValueHand[i] == sortedValueHand[i-1])
                 {
-                    //set index of one
                     cardIndexes[index] = i;
                     index++;
-                    //set index of other
                     cardIndexes[index] = i - 1;
-                    //decrement i so we skip over the next check
+                    index++;
                     i--;
                 }
-                //If it's not a pair then check if we can set it to high card
                 else if(highCardIndex < 0 || sortedValueHand[highCardIndex].MyValue < sortedValueHand[i].MyValue)
                 {
                     highCardIndex = i;
@@ -594,10 +552,7 @@ public class PlayerHand : GenHand
             }
         }
 
-        //Set the last index to the high card
         cardIndexes[4] = highCardIndex;
-        //Take the highest pair, which should be the lowest index in card indexes
-        //Calculate the value by doubling it
         int total = (int)sortedValueHand[cardIndexes[0]].MyValue * 2;
 
         int highCard = (int)sortedValueHand[highCardIndex].MyValue;
@@ -613,33 +568,25 @@ public class PlayerHand : GenHand
         int index = 0;
         for (int i = 0; i < sortedValueHand.Count - 1; i++)
         {
-            //If we have already found the pair
             if (index > 1 && index < 5)
             {
-                //lets add the highest cards
-                //if we add 3 and we are not at the end
-                //then we are at the lower end of the cards and we shoudln't add em
                 if (i + 3 >= sortedValueHand.Count)
                 {
                     cardIndexes[index] = i;
-                    i++;
+                    index++;
                 }
             }
 
             if (i+1 < sortedValueHand.Count)
             {
-                //Do we have a pair?
                 if (sortedValueHand[i].MyValue == sortedValueHand[i + 1].MyValue)
                 {
-                    //Put the pair in the card indexes
                     cardIndexes[index] = i;
                     index++;
                     cardIndexes[index] = i + 1;
                     index++;
-                    //Increment past the pair with i
                     i++;
 
-                    //Lets get the highest card
                     if (i + 1 == sortedValueHand.Count - 1)
                     {
                         highCard = (int)sortedValueHand[i - 1].MyValue;
@@ -653,10 +600,6 @@ public class PlayerHand : GenHand
 
         }
 
-
-        //If we still haven't filled up the card indexes
-        //Lets go down from the start of the pair
-        //And add cards until it's filled up
         int j = 1;
         while (index < 5)
         {
@@ -670,6 +613,22 @@ public class PlayerHand : GenHand
 
         potentialHandList.Add(CreateHandInfo(cardIndexes, Hand.OnePair, total, highCard));
 
+    }
+
+    protected int[] GetCardIndexesForValues(List<int> values)
+    {
+        int[] cardIndexes = new int[values.Count];
+        List<int> remainingIndexes = Enumerable.Range(0, sortedValueHand.Count).ToList();
+
+        for (int i = values.Count - 1; i >= 0; i--)
+        {
+            int targetValue = values[i] == 1 ? (int)VALUE.VA : values[i];
+            int cardIndex = remainingIndexes.Last(index => (int)sortedValueHand[index].MyValue == targetValue);
+            cardIndexes[i] = cardIndex;
+            remainingIndexes.Remove(cardIndex);
+        }
+
+        return cardIndexes;
     }
 
     public HandInfo CreateHandInfo(int[] cardIndexes, Hand handCombo, int total, int highCard)

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b4a40ae68444999b9c4f85de4ca3e75
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor.meta
+++ b/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99be4b3681c14cd299f252671d4a2f56
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PlayerHandTests.cs
+++ b/Assets/Tests/Editor/PlayerHandTests.cs
@@ -1,0 +1,162 @@
+using NUnit.Framework;
+using System.Linq;
+using UnityEngine;
+
+public class PlayerHandTests
+{
+    [Test]
+    public void EvaluateHand_DetectsRoyalFlush()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.H, VALUE.VK)),
+            Board(Card(SUIT.H, VALUE.VQ), Card(SUIT.H, VALUE.VJ), Card(SUIT.H, VALUE.V10), Card(SUIT.C, VALUE.V2), Card(SUIT.D, VALUE.V3)));
+
+        Assert.AreEqual(Hand.RoyalFlush, result.Hand);
+        Assert.AreEqual(Hand.RoyalFlush, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.VA, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsStraightFlush()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.S, VALUE.V8), Card(SUIT.S, VALUE.V7)),
+            Board(Card(SUIT.S, VALUE.V6), Card(SUIT.S, VALUE.V5), Card(SUIT.S, VALUE.V4), Card(SUIT.H, VALUE.VK), Card(SUIT.D, VALUE.V2)));
+
+        Assert.AreEqual(Hand.StraightFlush, result.Hand);
+        Assert.AreEqual(Hand.StraightFlush, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.V8, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsFourOfAKind_AndUsesCorrectHandTag()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.V9), Card(SUIT.S, VALUE.V9)),
+            Board(Card(SUIT.D, VALUE.V9), Card(SUIT.C, VALUE.V9), Card(SUIT.H, VALUE.VA), Card(SUIT.S, VALUE.V3), Card(SUIT.D, VALUE.V2)));
+
+        Assert.AreEqual(Hand.FourKind, result.Hand);
+        Assert.AreEqual(Hand.FourKind, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.VA, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsFullHouse()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VK), Card(SUIT.S, VALUE.VK)),
+            Board(Card(SUIT.D, VALUE.VK), Card(SUIT.C, VALUE.V10), Card(SUIT.H, VALUE.V10), Card(SUIT.S, VALUE.V4), Card(SUIT.D, VALUE.V2)));
+
+        Assert.AreEqual(Hand.FullHouse, result.Hand);
+        Assert.AreEqual(Hand.FullHouse, result.Info.HandCombo);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsFlush_WithSixSuitedCards()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.H, VALUE.V8)),
+            Board(Card(SUIT.H, VALUE.VK), Card(SUIT.H, VALUE.V10), Card(SUIT.H, VALUE.V5), Card(SUIT.H, VALUE.V2), Card(SUIT.C, VALUE.V3)));
+
+        Assert.AreEqual(Hand.Flush, result.Hand);
+        Assert.AreEqual(Hand.Flush, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.VA, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsFlush_WithSevenSuitedCards()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.S, VALUE.VA), Card(SUIT.S, VALUE.VJ)),
+            Board(Card(SUIT.S, VALUE.V9), Card(SUIT.S, VALUE.V7), Card(SUIT.S, VALUE.V5), Card(SUIT.S, VALUE.V3), Card(SUIT.S, VALUE.V2)));
+
+        Assert.AreEqual(Hand.Flush, result.Hand);
+        Assert.AreEqual(Hand.Flush, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.VA, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_DetectsWheelStraight()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.S, VALUE.V2)),
+            Board(Card(SUIT.D, VALUE.V3), Card(SUIT.C, VALUE.V4), Card(SUIT.H, VALUE.V5), Card(SUIT.S, VALUE.VK), Card(SUIT.D, VALUE.V9)));
+
+        Assert.AreEqual(Hand.Straight, result.Hand);
+        Assert.AreEqual(Hand.Straight, result.Info.HandCombo);
+        Assert.AreEqual((int)VALUE.V5, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_PrefersHigherStraightWindow()
+    {
+        var result = Evaluate(
+            Hole(Card(SUIT.H, VALUE.V9), Card(SUIT.S, VALUE.V8)),
+            Board(Card(SUIT.D, VALUE.V7), Card(SUIT.C, VALUE.V6), Card(SUIT.H, VALUE.V5), Card(SUIT.S, VALUE.V4), Card(SUIT.D, VALUE.V2)));
+
+        Assert.AreEqual(Hand.Straight, result.Hand);
+        Assert.AreEqual((int)VALUE.V9, result.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_UsesHighCardToBreakPairTie()
+    {
+        var stronger = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.S, VALUE.VA)),
+            Board(Card(SUIT.D, VALUE.VK), Card(SUIT.C, VALUE.VQ), Card(SUIT.H, VALUE.V9), Card(SUIT.S, VALUE.V4), Card(SUIT.D, VALUE.V2)));
+
+        var weaker = Evaluate(
+            Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.S, VALUE.VA)),
+            Board(Card(SUIT.D, VALUE.VJ), Card(SUIT.C, VALUE.V10), Card(SUIT.H, VALUE.V8), Card(SUIT.S, VALUE.V4), Card(SUIT.D, VALUE.V2)));
+
+        Assert.AreEqual(Hand.OnePair, stronger.Hand);
+        Assert.Greater(stronger.Info.HighCard, weaker.Info.HighCard);
+    }
+
+    [Test]
+    public void EvaluateHand_ResetsStateBetweenEvaluations()
+    {
+        var playerHand = Hole(Card(SUIT.H, VALUE.VA), Card(SUIT.S, VALUE.VK));
+
+        var first = Evaluate(playerHand,
+            Board(Card(SUIT.D, VALUE.VQ), Card(SUIT.C, VALUE.VJ), Card(SUIT.H, VALUE.V10), Card(SUIT.S, VALUE.V2), Card(SUIT.D, VALUE.V3)));
+        var second = Evaluate(playerHand,
+            Board(Card(SUIT.H, VALUE.V9), Card(SUIT.S, VALUE.V9), Card(SUIT.D, VALUE.V4), Card(SUIT.C, VALUE.V3), Card(SUIT.H, VALUE.V2)));
+
+        Assert.AreEqual(Hand.Straight, first.Hand);
+        Assert.AreEqual(Hand.OnePair, second.Hand);
+    }
+
+    private static (Hand Hand, HandInfo Info) Evaluate(PlayerHand playerHand, GenHand board)
+    {
+        var hand = playerHand.EvaluateHand(board);
+        return (hand, playerHand.FinalHandInfo);
+    }
+
+    private static PlayerHand Hole(params Card[] cards)
+    {
+        var hand = new PlayerHand();
+        foreach (var card in cards)
+        {
+            hand.DealCard(card);
+        }
+
+        return hand;
+    }
+
+    private static GenHand Board(params Card[] cards)
+    {
+        var board = new GenHand();
+        foreach (var card in cards)
+        {
+            board.DealCard(card);
+        }
+
+        return board;
+    }
+
+    private static Card Card(SUIT suit, VALUE value)
+    {
+        return new Card { MySuit = suit, MyValue = value };
+    }
+}

--- a/Assets/Tests/Editor/PlayerHandTests.cs.meta
+++ b/Assets/Tests/Editor/PlayerHandTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e21c170d265e4a1da6a73d584d8ff7d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/Poker.Tests.asmdef
+++ b/Assets/Tests/Editor/Poker.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Poker.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false,
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ]
+}

--- a/Assets/Tests/Editor/Poker.Tests.asmdef.meta
+++ b/Assets/Tests/Editor/Poker.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 784f6507eb9f43b2896224e2b1e56f09
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/rules-test-cases.md
+++ b/docs/rules-test-cases.md
@@ -1,0 +1,56 @@
+# Poker Rules Test Cases
+
+Canonical hand-evaluation scenarios for Milestone 0.
+
+## Royal Flush
+- Hole: Ah Kh
+- Board: Qh Jh Th 2c 3d
+- Expected: Royal Flush
+
+## Straight Flush
+- Hole: 8s 7s
+- Board: 6s 5s 4s Kh 2d
+- Expected: Straight Flush, high card 8
+
+## Four of a Kind
+- Hole: 9h 9s
+- Board: 9d 9c Ah 3s 2d
+- Expected: Four of a Kind, kicker A
+
+## Full House
+- Hole: Kh Ks
+- Board: Kd Tc Th 4s 2d
+- Expected: Full House, Kings over Tens
+
+## Flush with Six Suited Cards
+- Hole: Ah 8h
+- Board: Kh Th 5h 2h 3c
+- Expected: Flush, high card A
+
+## Flush with Seven Suited Cards
+- Hole: As Js
+- Board: 9s 7s 5s 3s 2s
+- Expected: Flush, high card A
+
+## Wheel Straight
+- Hole: Ah 2s
+- Board: 3d 4c 5h Ks 9d
+- Expected: Straight, high card 5
+
+## Higher Straight Window
+- Hole: 9h 8s
+- Board: 7d 6c 5h 4s 2d
+- Expected: Straight, high card 9
+
+## Pair Tie Breaker
+- Hand A Hole: Ah As
+- Hand A Board: Kd Qc 9h 4s 2d
+- Expected: Pair of Aces, kicker K
+- Hand B Hole: Ah As
+- Hand B Board: Jd Tc 8h 4s 2d
+- Expected: Pair of Aces, kicker J
+- Winner: Hand A
+
+## State Reset Between Evaluations
+- Evaluate one straight, then one pair using the same PlayerHand instance.
+- Expected: second result reflects only current cards.


### PR DESCRIPTION
Implements Milestone 0 groundwork for multiplayer MVP by hardening hand-evaluation correctness and adding deterministic editor tests.

What changed:
- added EditMode test assembly and hand-evaluation coverage
- documented canonical rules scenarios in docs/rules-test-cases.md
- fixed flush detection to handle 6/7 suited cards
- fixed straight detection windowing and added wheel straight support
- fixed Four of a Kind to emit the correct hand tag and kicker
- cleared cached evaluation dictionaries/lists between evaluations to avoid stale state

Done when criteria:
- Hand-ranking tests pass with stable expected outcomes

Review notes:
- I could not run the Unity test runner in this environment because the project targets Unity 2020.2.4f1 and only 2022 editors are installed locally. The tests are included and ready to run in the intended editor version.
- I did not add the in-editor scripted debug harness yet; this PR focuses on correctness fixes + deterministic test coverage first.