### PR TITLE
[Athena] Milestone 1 authoritative multiplayer core

### DIFF
--- a/Assets/Scripts/Networking/PokerAuthorityController.cs
+++ b/Assets/Scripts/Networking/PokerAuthorityController.cs
@@ -1,0 +1,79 @@
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+public class PokerAuthorityController : MonoBehaviourPunCallbacks
+{
+    public static PokerAuthorityController Instance { get; private set; }
+
+    private PokerGameSnapshot latestSnapshot;
+    public PokerGameSnapshot LatestSnapshot { get { return latestSnapshot; } }
+
+    private PokerStateMachine psm;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        psm = GetComponent<PokerStateMachine>();
+    }
+
+    public bool HasAuthority()
+    {
+        return !PhotonNetwork.InRoom || PhotonNetwork.IsMasterClient;
+    }
+
+    public bool CanControlPlayer(PokerPlayer player)
+    {
+        if (player == null)
+        {
+            return false;
+        }
+
+        if (!PhotonNetwork.InRoom)
+        {
+            return true;
+        }
+
+        Player local = PhotonNetwork.LocalPlayer;
+        if (local == null)
+        {
+            return false;
+        }
+
+        return player.ActorNumber == local.ActorNumber;
+    }
+
+    public bool TryBeginAuthorityMutation(string reason)
+    {
+        if (HasAuthority())
+        {
+            return true;
+        }
+
+        Debug.LogWarning("Blocked non-authority mutation: " + reason);
+        return false;
+    }
+
+    public void PublishSnapshot(string phaseOverride = null)
+    {
+        if (psm == null)
+        {
+            psm = GetComponent<PokerStateMachine>();
+        }
+
+        latestSnapshot = PokerGameSnapshot.Capture(psm, phaseOverride);
+        Debug.Log("Published snapshot phase=" + latestSnapshot.Phase + " turnActor=" + latestSnapshot.CurrentTurnActorNumber + " pot=" + latestSnapshot.Pot);
+    }
+
+    public override void OnMasterClientSwitched(Player newMasterClient)
+    {
+        base.OnMasterClientSwitched(newMasterClient);
+        PublishSnapshot("MasterClientSwitched");
+    }
+}

--- a/Assets/Scripts/Networking/PokerAuthorityController.cs
+++ b/Assets/Scripts/Networking/PokerAuthorityController.cs
@@ -6,6 +6,22 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
 {
     public static PokerAuthorityController Instance { get; private set; }
 
+    public const string MutationReasonStartRound = "StartRound";
+    public const string MutationReasonRestartRound = "RestartRound";
+    public const string MutationReasonGameStateRoundStartRun = "GameStateRoundStart.Run";
+    public const string MutationReasonGameStateDealRun = "GameStateDeal.Run";
+    public const string MutationReasonGameStateBettingRun = "GameStateBetting.Run";
+    public const string MutationReasonGameStateBettingReceiveAction = "GameStateBetting.ReceiveAction";
+    public const string MutationReasonGameStateRoundEndRun = "GameStateRoundEnd.Run";
+
+    public const string SnapshotPhaseAwaitingAuthorityStart = "AwaitingAuthorityStart";
+    public const string SnapshotPhaseMasterClientSwitched = "MasterClientSwitched";
+    public const string SnapshotPhaseRoundStartReadyToDeal = "RoundStart.ReadyToDeal";
+    public const string SnapshotPhaseBettingStarted = "Betting.Started";
+    public const string SnapshotPhaseBettingWaitingForAction = "Betting.WaitingForAction";
+    public const string SnapshotPhaseBettingActionApplied = "Betting.ActionApplied";
+    public const string SnapshotPhaseRoundEndResolved = "RoundEnd.Resolved";
+
     private PokerGameSnapshot latestSnapshot;
     public PokerGameSnapshot LatestSnapshot { get { return latestSnapshot; } }
 
@@ -35,6 +51,8 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
             return false;
         }
 
+        // Offline/single-player sessions do not have Photon ownership, so we allow
+        // local control here and only enforce seat ownership once we are in a room.
         if (!PhotonNetwork.InRoom)
         {
             return true;
@@ -74,6 +92,6 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
     public override void OnMasterClientSwitched(Player newMasterClient)
     {
         base.OnMasterClientSwitched(newMasterClient);
-        PublishSnapshot("MasterClientSwitched");
+        PublishSnapshot(SnapshotPhaseMasterClientSwitched);
     }
 }

--- a/Assets/Scripts/Networking/PokerAuthorityController.cs.meta
+++ b/Assets/Scripts/Networking/PokerAuthorityController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34da1dfc7f3444749c04c72c35002114
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking/PokerGameSnapshot.cs
+++ b/Assets/Scripts/Networking/PokerGameSnapshot.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+[Serializable]
+public class PokerGameSnapshot
+{
+    public string Phase;
+    public int DealerActorNumber;
+    public int SmallBlindActorNumber;
+    public int BigBlindActorNumber;
+    public int CurrentTurnActorNumber;
+    public float Pot;
+    public float HighestBet;
+    public int CommunityCardCount;
+    public List<CardSnapshot> CommunityCards = new List<CardSnapshot>();
+    public List<PlayerSnapshot> Players = new List<PlayerSnapshot>();
+    public string UpdatedBy;
+    public string UpdatedAtUtc;
+
+    public static PokerGameSnapshot Capture(PokerStateMachine psm, string phaseOverride = null)
+    {
+        PokerGameSnapshot snapshot = new PokerGameSnapshot();
+        snapshot.Phase = phaseOverride ?? psm.GetCurrentPhaseName();
+        snapshot.DealerActorNumber = psm.GetDealerActorNumber();
+        snapshot.SmallBlindActorNumber = psm.GetBlindActorNumber(true);
+        snapshot.BigBlindActorNumber = psm.GetBlindActorNumber(false);
+        snapshot.CurrentTurnActorNumber = psm.GetCurrentTurnActorNumber();
+        snapshot.Pot = psm.BetManager != null ? psm.BetManager.PotAmount : 0f;
+        snapshot.HighestBet = psm.HighestBet.amount;
+        snapshot.CommunityCardCount = psm.riverHand != null ? psm.riverHand.CardHand.Count : 0;
+        snapshot.UpdatedBy = PhotonNetwork.LocalPlayer != null ? PhotonNetwork.LocalPlayer.NickName : "Offline";
+        snapshot.UpdatedAtUtc = DateTime.UtcNow.ToString("o");
+
+        if (psm.riverHand != null)
+        {
+            snapshot.CommunityCards = psm.riverHand.CardHand.Select(CardSnapshot.FromCard).ToList();
+        }
+
+        if (psm.PlayersInGame != null)
+        {
+            snapshot.Players = psm.PlayersInGame.Select(player => PlayerSnapshot.FromPlayer(psm, player)).ToList();
+        }
+
+        return snapshot;
+    }
+}
+
+[Serializable]
+public class PlayerSnapshot
+{
+    public int SeatIndex;
+    public int ActorNumber;
+    public string DisplayName;
+    public float Chips;
+    public float CurrentBet;
+    public bool Folded;
+    public bool AllIn;
+    public bool IsLocalPlayer;
+    public bool HoleCardsVisibleToLocalClient;
+    public List<CardSnapshot> HoleCards = new List<CardSnapshot>();
+
+    public static PlayerSnapshot FromPlayer(PokerStateMachine psm, PokerPlayer player)
+    {
+        PlayerSnapshot snapshot = new PlayerSnapshot();
+        snapshot.SeatIndex = player.PlayerID;
+        snapshot.ActorNumber = player.ActorNumber;
+        snapshot.DisplayName = player.DisplayName;
+        snapshot.Chips = player.PlayerMoney;
+        snapshot.CurrentBet = player.CurrBet.amount;
+        snapshot.Folded = player.IsFolded;
+        snapshot.AllIn = Mathf.Approximately(player.PlayerMoney, 0f);
+        snapshot.IsLocalPlayer = player.ActorNumber == PhotonNetwork.LocalPlayer?.ActorNumber;
+        snapshot.HoleCardsVisibleToLocalClient = player.CanRevealHoleCardsTo(PhotonNetwork.LocalPlayer);
+
+        if (snapshot.HoleCardsVisibleToLocalClient)
+        {
+            snapshot.HoleCards = player.PlayerHand.DealtHand.Select(CardSnapshot.FromCard).ToList();
+        }
+        else
+        {
+            snapshot.HoleCards = player.PlayerHand.DealtHand.Select(_ => CardSnapshot.Hidden()).ToList();
+        }
+
+        return snapshot;
+    }
+}
+
+[Serializable]
+public class CardSnapshot
+{
+    public string Suit;
+    public string Value;
+    public bool IsHidden;
+
+    public static CardSnapshot FromCard(Card card)
+    {
+        return new CardSnapshot
+        {
+            Suit = card.MySuit.ToString(),
+            Value = card.MyValue.ToString(),
+            IsHidden = false
+        };
+    }
+
+    public static CardSnapshot Hidden()
+    {
+        return new CardSnapshot
+        {
+            Suit = "Hidden",
+            Value = "Hidden",
+            IsHidden = true
+        };
+    }
+}

--- a/Assets/Scripts/Networking/PokerGameSnapshot.cs
+++ b/Assets/Scripts/Networking/PokerGameSnapshot.cs
@@ -8,6 +8,8 @@ using UnityEngine;
 [Serializable]
 public class PokerGameSnapshot
 {
+    public const string DealPhasePrefix = "Deal.";
+
     public string Phase;
     public int DealerActorNumber;
     public int SmallBlindActorNumber;
@@ -21,6 +23,14 @@ public class PokerGameSnapshot
     public string UpdatedBy;
     public string UpdatedAtUtc;
 
+    public static string BuildDealPhaseName(DealingState dealState)
+    {
+        return DealPhasePrefix + dealState;
+    }
+
+    // A snapshot is a read-only picture of the authoritative table state at a moment in time.
+    // We capture it on the authority side so later milestones can broadcast or rehydrate from
+    // one consistent model instead of rebuilding state from scattered scene objects.
     public static PokerGameSnapshot Capture(PokerStateMachine psm, string phaseOverride = null)
     {
         PokerGameSnapshot snapshot = new PokerGameSnapshot();

--- a/Assets/Scripts/Networking/PokerGameSnapshot.cs.meta
+++ b/Assets/Scripts/Networking/PokerGameSnapshot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1f0a6f5dc38458d922cc9e3b5ebafb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerObject.cs
+++ b/Assets/Scripts/Player/PlayerObject.cs
@@ -27,7 +27,7 @@ public class PlayerObject : MonoBehaviour
     {
         player = _player;
         playerNum = player.PlayerID;
-        username = "Player " + playerNum;
+        username = player.DisplayName;
     }
 
     public void CreateCards()
@@ -53,6 +53,12 @@ public class PlayerObject : MonoBehaviour
 
     public void Call()
     {
+        if (!psm.AuthorityController.CanControlPlayer(player))
+        {
+            Debug.Log("Cannot control this seat from the local client.");
+            return;
+        }
+
         Debug.Log("Highest bet is "+ psm.HighestBet.amount);
         bool callBet = player.RaiseCurrentBetTo(psm.HighestBet.amount);
 
@@ -64,6 +70,12 @@ public class PlayerObject : MonoBehaviour
 
     public void Raise(float amount)
     {
+        if (!psm.AuthorityController.CanControlPlayer(player))
+        {
+            Debug.Log("Cannot control this seat from the local client.");
+            return;
+        }
+
         bool raiseBet = player.RaiseCurrentBetTo(psm.HighestBet.amount + amount);
 
         if (!raiseBet)
@@ -74,6 +86,12 @@ public class PlayerObject : MonoBehaviour
 
     public void Fold()
     {
+        if (!psm.AuthorityController.CanControlPlayer(player))
+        {
+            Debug.Log("Cannot control this seat from the local client.");
+            return;
+        }
+
         bool foldPlayer = player.SetFolded(true);
 
         if (!foldPlayer)
@@ -84,6 +102,12 @@ public class PlayerObject : MonoBehaviour
 
     public void Check()
     {
+        if (!psm.AuthorityController.CanControlPlayer(player))
+        {
+            Debug.Log("Cannot control this seat from the local client.");
+            return;
+        }
+
         if (psm.HighestBet.amount == 0)
         {
             bool check = player.RaiseCurrentBetTo(psm.HighestBet.amount);

--- a/Assets/Scripts/Player/PokerPlayer.cs
+++ b/Assets/Scripts/Player/PokerPlayer.cs
@@ -2,11 +2,15 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using Photon.Realtime;
 
 public class PokerPlayer
 {
     protected int playerID;
     public int PlayerID { get { return playerID; } }
+
+    public int ActorNumber { get; private set; }
+    public string DisplayName { get; private set; }
 
     protected float playerMoney;
     public float PlayerMoney { get { return playerMoney; } }
@@ -29,6 +33,31 @@ public class PokerPlayer
         playerID = _id;
         playerHand = new PlayerHand();
         currBet = new Bet(0, playerID);
+        ActorNumber = -1;
+        DisplayName = "Seat " + _id;
+    }
+
+    public void BindToPhotonPlayer(Player photonPlayer)
+    {
+        if (photonPlayer == null)
+        {
+            ActorNumber = -1;
+            DisplayName = "Seat " + playerID;
+            return;
+        }
+
+        ActorNumber = photonPlayer.ActorNumber;
+        DisplayName = string.IsNullOrEmpty(photonPlayer.NickName) ? "Player " + photonPlayer.ActorNumber : photonPlayer.NickName;
+    }
+
+    public bool CanRevealHoleCardsTo(Player viewer)
+    {
+        if (viewer == null)
+        {
+            return true;
+        }
+
+        return viewer.ActorNumber == ActorNumber;
     }
 
     public bool SetFolded(bool _isFolded)

--- a/Assets/Scripts/Poker/GameStateBetting.cs
+++ b/Assets/Scripts/Poker/GameStateBetting.cs
@@ -18,13 +18,13 @@ public class GameStateBetting : GameState
     public override void Run()
     {
         base.Run();
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.Run"))
+        if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateBettingRun))
         {
             return;
         }
 
         StartBetRound();
-        psm.AuthorityController.PublishSnapshot("Betting.Started");
+        psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseBettingStarted);
     }
 
     private void StartBetRound()
@@ -60,9 +60,11 @@ public class GameStateBetting : GameState
     {
         PokerPlayer nextPlayer = psm.GetNextPlayerInQueue();
         currPlayerBetting = nextPlayer;
+        // Only the seat owned by this client should be interactable in multiplayer.
+        // Offline we still allow local control so the table remains playable without Photon.
         nextPlayer.canInput = psm.AuthorityController.CanControlPlayer(nextPlayer);
         nextPlayer.OnPlayerEvent += ReceiveAction;
-        psm.AuthorityController.PublishSnapshot("Betting.WaitingForAction");
+        psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseBettingWaitingForAction);
     }
 
 
@@ -75,7 +77,7 @@ public class GameStateBetting : GameState
 
     private void ReceiveAction(Bet newBet)
     {
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.ReceiveAction")) { return; }
+        if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateBettingReceiveAction)) { return; }
         if (psm.GetNextPlayerInQueue().PlayerID != newBet.playerID) { return; }
 
         Debug.Log("Receive Action: " + newBet.amount);
@@ -89,7 +91,7 @@ public class GameStateBetting : GameState
             AddBet(newBet);
         }
 
-        psm.AuthorityController.PublishSnapshot("Betting.ActionApplied");
+        psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseBettingActionApplied);
 
         if (psm.queuePlayersInRound.Count <= 1)
         {

--- a/Assets/Scripts/Poker/GameStateBetting.cs
+++ b/Assets/Scripts/Poker/GameStateBetting.cs
@@ -18,7 +18,13 @@ public class GameStateBetting : GameState
     public override void Run()
     {
         base.Run();
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.Run"))
+        {
+            return;
+        }
+
         StartBetRound();
+        psm.AuthorityController.PublishSnapshot("Betting.Started");
     }
 
     private void StartBetRound()
@@ -53,8 +59,10 @@ public class GameStateBetting : GameState
     private void RequestAction()
     {
         PokerPlayer nextPlayer = psm.GetNextPlayerInQueue();
-        nextPlayer.canInput = true;
+        currPlayerBetting = nextPlayer;
+        nextPlayer.canInput = psm.AuthorityController.CanControlPlayer(nextPlayer);
         nextPlayer.OnPlayerEvent += ReceiveAction;
+        psm.AuthorityController.PublishSnapshot("Betting.WaitingForAction");
     }
 
 
@@ -62,10 +70,12 @@ public class GameStateBetting : GameState
     {
         base.ResetState();
         highestBet = new Bet(0, -1);
+        currPlayerBetting = null;
     }
 
     private void ReceiveAction(Bet newBet)
     {
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.ReceiveAction")) { return; }
         if (psm.GetNextPlayerInQueue().PlayerID != newBet.playerID) { return; }
 
         Debug.Log("Receive Action: " + newBet.amount);
@@ -79,13 +89,14 @@ public class GameStateBetting : GameState
             AddBet(newBet);
         }
 
+        psm.AuthorityController.PublishSnapshot("Betting.ActionApplied");
+
         if (psm.queuePlayersInRound.Count <= 1)
         {
             GoToEndRound();
         }
         else if (highestBet.playerID == psm.GetNextPlayerInQueue().PlayerID)
         {
-            //We need to skip over the next player and go to round
             GoToDealing();
         }
         else
@@ -98,8 +109,6 @@ public class GameStateBetting : GameState
     {
         PokerPlayer p = psm.GetPlayerWithID(newBet.playerID);
 
-        //To check for highest bet, we check how the current bet on the player has changed
-        //New bet could be a call or a raise, but it won't include the amount previously bet
         if (highestBet.playerID == -1 || highestBet.amount < p.CurrBet.amount)
         {
             highestBet = p.CurrBet;
@@ -107,7 +116,7 @@ public class GameStateBetting : GameState
         }
 
         psm.queuePlayersInRound.Enqueue(p);
-        psm.BetManager.AddToPot(newBet.amount);        
+        psm.BetManager.AddToPot(newBet.amount);
     }
 
     protected void GoToDealing()

--- a/Assets/Scripts/Poker/GameStateDeal.cs
+++ b/Assets/Scripts/Poker/GameStateDeal.cs
@@ -14,7 +14,13 @@ public class GameStateDeal : GameState
     public override void Run()
     {
         base.Run();
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateDeal.Run"))
+        {
+            return;
+        }
+
         Deal();
+        psm.AuthorityController.PublishSnapshot("Deal." + dealState);
     }
 
     protected void Deal()
@@ -90,6 +96,7 @@ public class GameStateDeal : GameState
             p.PlayerHand.ClearHand();
         }
 
+        psm.riverHand.ClearHand();
         dealState = 0;
     }
 }

--- a/Assets/Scripts/Poker/GameStateDeal.cs
+++ b/Assets/Scripts/Poker/GameStateDeal.cs
@@ -14,13 +14,13 @@ public class GameStateDeal : GameState
     public override void Run()
     {
         base.Run();
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateDeal.Run"))
+        if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateDealRun))
         {
             return;
         }
 
         Deal();
-        psm.AuthorityController.PublishSnapshot("Deal." + dealState);
+        psm.AuthorityController.PublishSnapshot(PokerGameSnapshot.BuildDealPhaseName(dealState));
     }
 
     protected void Deal()

--- a/Assets/Scripts/Poker/GameStateRoundEnd.cs
+++ b/Assets/Scripts/Poker/GameStateRoundEnd.cs
@@ -17,7 +17,7 @@ public class GameStateRoundEnd : GameState
 
     public override void Run()
     {
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateRoundEnd.Run"))
+        if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateRoundEndRun))
         {
             return;
         }
@@ -38,7 +38,7 @@ public class GameStateRoundEnd : GameState
         }
 
         psm.BetManager.GivePotToPlayer(winningPlayer);
-        psm.AuthorityController.PublishSnapshot("RoundEnd.Resolved");
+        psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseRoundEndResolved);
 
         base.Run();
     }
@@ -50,6 +50,8 @@ public class GameStateRoundEnd : GameState
         winningMessage = "";
     }
 
+    // Each remaining player evaluates against the shared community cards before
+    // winner comparison so the authority is comparing finalized hand metadata.
     protected void EvaluateAllHandsInRound()
     {
         foreach (PokerPlayer p in psm.queuePlayersInRound)
@@ -58,6 +60,7 @@ public class GameStateRoundEnd : GameState
         }
     }
 
+    // Returns the player ID of the best hand still in the round.
     protected int EvaluateHands()
     {
         EvaluateAllHandsInRound();
@@ -89,6 +92,8 @@ public class GameStateRoundEnd : GameState
         return highestPlayer.PlayerID;
     }
 
+    // Negative means the first hand wins, positive means the second hand wins, and
+    // zero means the current comparison inputs are tied on the supported tiebreakers.
     private int CompareHands(PlayerHand negHand, PlayerHand posHand)
     {
         Hand negCardHand = negHand.FinalHandInfo.HandCombo;

--- a/Assets/Scripts/Poker/GameStateRoundEnd.cs
+++ b/Assets/Scripts/Poker/GameStateRoundEnd.cs
@@ -17,11 +17,15 @@ public class GameStateRoundEnd : GameState
 
     public override void Run()
     {
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateRoundEnd.Run"))
+        {
+            return;
+        }
 
         if (psm.queuePlayersInRound.Count <= 1)
         {
             winningPlayer = psm.queuePlayersInRound.Peek();
-            winningMessage = "Winner is " + winningPlayer.PlayerID + "  by default.";
+            winningMessage = "Winner is " + winningPlayer.DisplayName + " by default.";
         }
         else
         {
@@ -30,10 +34,11 @@ public class GameStateRoundEnd : GameState
             {
                 Debug.Log("P" + p.PlayerID + "  has " + p.PlayerHand.FinalHandInfo.HandCombo);
             }
-            winningMessage = "Winner is " + winningPlayer.PlayerID + " with a hand of " + winningPlayer.PlayerHand.FinalHandInfo.HandCombo;
+            winningMessage = "Winner is " + winningPlayer.DisplayName + " with a hand of " + winningPlayer.PlayerHand.FinalHandInfo.HandCombo;
         }
 
         psm.BetManager.GivePotToPlayer(winningPlayer);
+        psm.AuthorityController.PublishSnapshot("RoundEnd.Resolved");
 
         base.Run();
     }
@@ -45,7 +50,6 @@ public class GameStateRoundEnd : GameState
         winningMessage = "";
     }
 
-    //Evaluate all the hands so we know we have the final hand info ready
     protected void EvaluateAllHandsInRound()
     {
         foreach (PokerPlayer p in psm.queuePlayersInRound)
@@ -73,12 +77,10 @@ public class GameStateRoundEnd : GameState
                 int compareResults = CompareHands(p.PlayerHand, highestPlayer.PlayerHand);
                 if (compareResults < 0)
                 {
-                    //new Highest hand
                     highestPlayer = p;
                 }
                 else if (compareResults == 0)
                 {
-                    //we tied
                 }
 
             }
@@ -98,7 +100,6 @@ public class GameStateRoundEnd : GameState
         int negHighCard = negHand.FinalHandInfo.HighCard;
         int posHighCard = posHand.FinalHandInfo.HighCard;
 
-        //eval hands
         if (negCardHand > posCardHand)
         {
             return -1;
@@ -107,9 +108,8 @@ public class GameStateRoundEnd : GameState
         {
             return 1;
         }
-        else // if the hands are the same evaluate the values
+        else
         {
-            //first evaluate the higher value
             if (negTotal > posTotal)
             {
                 return -1;
@@ -118,9 +118,8 @@ public class GameStateRoundEnd : GameState
             {
                 return 1;
             }
-            else //if both have the same then check highest card
+            else
             {
-                //first evaluate the higher value
                 if (negHighCard > posHighCard)
                 {
                     return -1;
@@ -129,7 +128,7 @@ public class GameStateRoundEnd : GameState
                 {
                     return 1;
                 }
-                else //its a fucking tie
+                else
                 {
                     return 0;
                 }

--- a/Assets/Scripts/Poker/GameStateRoundStart.cs
+++ b/Assets/Scripts/Poker/GameStateRoundStart.cs
@@ -12,8 +12,15 @@ public class GameStateRoundStart : GameState
     public override void Run()
     {
         base.Run();
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateRoundStart.Run"))
+        {
+            return;
+        }
+
+        psm.MapPhotonPlayersToSeats();
         CreateDeck();
         AddRoundPlayers();
+        psm.AuthorityController.PublishSnapshot("RoundStart.ReadyToDeal");
         psm.SetState(psm.StateDeal);
     }
 
@@ -27,7 +34,6 @@ public class GameStateRoundStart : GameState
     {
         psm.queuePlayersInRound.Clear();
 
-        //Lets get the index of the small blind because we'll have to force them to start and play bet in the beginning
         List<PokerPlayer> activePlayers = psm.GetActivePlayers();
         int firstIndex = (activePlayers.IndexOf(psm.BetManager.BigBlindPlayer) + 1) % activePlayers.Count;
 

--- a/Assets/Scripts/Poker/GameStateRoundStart.cs
+++ b/Assets/Scripts/Poker/GameStateRoundStart.cs
@@ -12,7 +12,7 @@ public class GameStateRoundStart : GameState
     public override void Run()
     {
         base.Run();
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateRoundStart.Run"))
+        if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateRoundStartRun))
         {
             return;
         }
@@ -20,7 +20,7 @@ public class GameStateRoundStart : GameState
         psm.MapPhotonPlayersToSeats();
         CreateDeck();
         AddRoundPlayers();
-        psm.AuthorityController.PublishSnapshot("RoundStart.ReadyToDeal");
+        psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseRoundStartReadyToDeal);
         psm.SetState(psm.StateDeal);
     }
 

--- a/Assets/Scripts/Poker/PokerStateMachine.cs
+++ b/Assets/Scripts/Poker/PokerStateMachine.cs
@@ -2,7 +2,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using Photon.Pun;
+using Photon.Realtime;
+using System.Linq;
 
+[RequireComponent(typeof(PokerAuthorityController))]
 public class PokerStateMachine : StateMachine
 {
     private static PokerStateMachine psm;
@@ -36,6 +40,9 @@ public class PokerStateMachine : StateMachine
 
     private float buyInAmount = 10f;
 
+    private PokerAuthorityController authorityController;
+    public PokerAuthorityController AuthorityController { get { return authorityController; } }
+
     public DealingState DealState { get { return stateDeal.dealState; } }
     public Bet HighestBet { get { return stateBetting.HighestBet; } }
 
@@ -47,7 +54,7 @@ public class PokerStateMachine : StateMachine
     protected GameStateDeal stateDeal;
     public GameStateDeal StateDeal { get { return stateDeal; } }
     protected GameStateBetting stateBetting;
-    public GameStateBetting StateBetting { get { return stateBetting; } } 
+    public GameStateBetting StateBetting { get { return stateBetting; } }
     protected GameStateRoundEnd stateRoundEnd;
     public GameStateRoundEnd StateRoundEnd { get { return stateRoundEnd; } }
 
@@ -62,12 +69,20 @@ public class PokerStateMachine : StateMachine
             psm = this;
         }
 
+        authorityController = GetComponent<PokerAuthorityController>();
         SetUpGame();
     }
 
     public void Start()
     {
-        StartRound();
+        if (authorityController.HasAuthority())
+        {
+            StartRound();
+        }
+        else
+        {
+            authorityController.PublishSnapshot("AwaitingAuthorityStart");
+        }
     }
 
     public void SetUpGame()
@@ -78,9 +93,11 @@ public class PokerStateMachine : StateMachine
         for (int i = 0; i < NUM_OF_PLAYERS; i++)
         {
             PokerPlayer p = new PokerPlayer(i);
-            p.AddMoney(buyInAmount); 
+            p.AddMoney(buyInAmount);
             playersInGame.Add(p);
         }
+
+        MapPhotonPlayersToSeats();
 
         queuePlayersInRound = new Queue<PokerPlayer>();
 
@@ -94,11 +111,21 @@ public class PokerStateMachine : StateMachine
 
     public void StartRound()
     {
+        if (!authorityController.TryBeginAuthorityMutation("StartRound"))
+        {
+            return;
+        }
+
         SetState(stateRoundStart);
     }
 
     public void RestartRound()
     {
+        if (!authorityController.TryBeginAuthorityMutation("RestartRound"))
+        {
+            return;
+        }
+
         betManager.NewRound();
         stateDeal.NewRound();
         DestroyAllVisuals();
@@ -108,13 +135,26 @@ public class PokerStateMachine : StateMachine
     public override void SetState(GameState inputState)
     {
         base.SetState(inputState);
+        authorityController.PublishSnapshot(inputState.GetType().Name);
         inputState.Run();
+        authorityController.PublishSnapshot(inputState.GetType().Name + ".RunComplete");
     }
 
     public PokerPlayer GetPlayerWithID(int _id)
     {
         PokerPlayer currPlayer = playersInGame.Find(x => x.PlayerID == _id);
         return currPlayer;
+    }
+
+    public PokerPlayer GetPlayerForLocalClient()
+    {
+        Player local = PhotonNetwork.LocalPlayer;
+        if (local == null)
+        {
+            return GetPlayerWithID(0);
+        }
+
+        return playersInGame.FirstOrDefault(player => player.ActorNumber == local.ActorNumber);
     }
 
     public void CreateAllHandsVisuals()
@@ -202,7 +242,6 @@ public class PokerStateMachine : StateMachine
 
         int counter = 0;
         PokerPlayer startPlayer;
-        //search for a start player that's not folded and return that
         do
         {
             counter++;
@@ -211,5 +250,55 @@ public class PokerStateMachine : StateMachine
         while (startPlayer.IsFolded && counter < playersInGame.Count);
 
         return startPlayer;
+    }
+
+    public void MapPhotonPlayersToSeats()
+    {
+        Player[] photonPlayers = PhotonNetwork.PlayerList;
+
+        for (int i = 0; i < playersInGame.Count; i++)
+        {
+            if (i < photonPlayers.Length)
+            {
+                playersInGame[i].BindToPhotonPlayer(photonPlayers[i]);
+            }
+            else
+            {
+                playersInGame[i].BindToPhotonPlayer(null);
+            }
+        }
+    }
+
+    public string GetCurrentPhaseName()
+    {
+        if (currentState == null)
+        {
+            return "Uninitialized";
+        }
+
+        return currentState.GetType().Name;
+    }
+
+    public int GetCurrentTurnActorNumber()
+    {
+        if (queuePlayersInRound == null || queuePlayersInRound.Count == 0)
+        {
+            return -1;
+        }
+
+        PokerPlayer player = queuePlayersInRound.Peek();
+        return player != null ? player.ActorNumber : -1;
+    }
+
+    public int GetBlindActorNumber(bool smallBlind)
+    {
+        PokerPlayer player = smallBlind ? BetManager.SmallBlindPlayer : BetManager.BigBlindPlayer;
+        return player != null ? player.ActorNumber : -1;
+    }
+
+    public int GetDealerActorNumber()
+    {
+        PokerPlayer dealer = BetManager.SmallBlindPlayer;
+        return dealer != null ? dealer.ActorNumber : -1;
     }
 }

--- a/Assets/Scripts/Poker/PokerStateMachine.cs
+++ b/Assets/Scripts/Poker/PokerStateMachine.cs
@@ -81,7 +81,7 @@ public class PokerStateMachine : StateMachine
         }
         else
         {
-            authorityController.PublishSnapshot("AwaitingAuthorityStart");
+            authorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseAwaitingAuthorityStart);
         }
     }
 
@@ -111,7 +111,7 @@ public class PokerStateMachine : StateMachine
 
     public void StartRound()
     {
-        if (!authorityController.TryBeginAuthorityMutation("StartRound"))
+        if (!authorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonStartRound))
         {
             return;
         }
@@ -121,7 +121,7 @@ public class PokerStateMachine : StateMachine
 
     public void RestartRound()
     {
-        if (!authorityController.TryBeginAuthorityMutation("RestartRound"))
+        if (!authorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonRestartRound))
         {
             return;
         }

--- a/docs/authoritative-multiplayer-core.md
+++ b/docs/authoritative-multiplayer-core.md
@@ -33,6 +33,17 @@ This pass establishes the authority/snapshot backbone for multiplayer MVP.
 - Produces a consistent serializable snapshot model for later RPC/event replication
 - Prevents local clients from controlling seats they do not own
 
+## Snapshot concept in plain English
+A snapshot is a serializable "photo" of the table at one moment in time.
+Instead of asking remote clients to infer state from a long chain of scene-side mutations,
+the authority can capture the important shared data in one model: phase, turn owner, blinds,
+pot, community cards, and per-player public state.
+
+In this milestone, snapshots are captured locally by the authority as the architecture backbone.
+They are not yet the thing driving remote client restoration. The point is to define one stable
+shape for the game state now, so Milestone 2+ can broadcast commands and/or snapshots without
+having to redesign the state model again.
+
 ## What is intentionally deferred to Milestone 2+
 - actual RPC/event broadcast of commands and snapshots
 - remote command validation pipeline (`Fold`, `Check`, `Call`, `Raise`)

--- a/docs/authoritative-multiplayer-core.md
+++ b/docs/authoritative-multiplayer-core.md
@@ -1,0 +1,43 @@
+# Milestone 1 — Authoritative Multiplayer Game Core
+
+This pass establishes the authority/snapshot backbone for multiplayer MVP.
+
+## Added
+- `PokerAuthorityController`
+  - central authority gate
+  - blocks non-authority state mutation
+  - publishes snapshots after key state changes
+- `PokerGameSnapshot`
+  - serializable snapshot of phase, blinds, turn actor, pot, highest bet, community cards, and per-player state
+  - hides opponent hole cards for non-owning clients
+- Photon seat mapping on `PokerPlayer`
+  - `ActorNumber`
+  - `DisplayName`
+  - ownership helper for card visibility
+
+## Updated
+- `PokerStateMachine`
+  - requires authority controller
+  - maps Photon players to seats
+  - only authority starts/restarts rounds
+  - publishes snapshots around state transitions
+- `GameStateRoundStart`, `GameStateDeal`, `GameStateBetting`, `GameStateRoundEnd`
+  - authority checks before mutating shared state
+  - snapshot publication during core round flow
+- `PlayerObject`
+  - local client can only control the seat mapped to its Photon actor
+
+## What this milestone does now
+- Establishes one source of truth for game-state mutation: the Photon master client
+- Tracks actor-number-to-seat mapping in gameplay state
+- Produces a consistent serializable snapshot model for later RPC/event replication
+- Prevents local clients from controlling seats they do not own
+
+## What is intentionally deferred to Milestone 2+
+- actual RPC/event broadcast of commands and snapshots
+- remote command validation pipeline (`Fold`, `Check`, `Call`, `Raise`)
+- reconnect restoration from received snapshots
+- full non-authority client rehydration from networked snapshot data
+
+## Notes
+This is the architecture spine, not the full replication layer. It sets up the model so Milestone 2 can wire action replication cleanly instead of bolting it on to purely local state.


### PR DESCRIPTION
Implements the Milestone 1 backbone for authoritative multiplayer game state.

What changed:
- added PokerAuthorityController to centralize authority checks and snapshot publication
- added serializable PokerGameSnapshot / PlayerSnapshot / CardSnapshot models
- mapped gameplay seats to Photon ActorNumber + display name
- gated round start, dealing, betting, and round-end mutations behind authority checks
- updated local controls so a client can only act on the seat it owns
- documented the architecture pass in docs/authoritative-multiplayer-core.md

Done when criteria:
- non-authority clients behave as viewers/input senders, while authority owns shared-state mutation

Review notes:
- this PR intentionally establishes the authority/snapshot backbone; it does not yet add full command RPC replication or snapshot rehydration on remote clients
- milestone 2 should build the Fold/Check/Call/Raise command pipeline on top of this model
- I did not run an end-to-end Unity multiplayer verification pass in this environment.