### PR TITLE
[Athena] Milestone 2 turn action replication

### DIFF
--- a/Assets/Scripts/Networking/PokerActionCommand.cs
+++ b/Assets/Scripts/Networking/PokerActionCommand.cs
@@ -1,0 +1,32 @@
+using System;
+
+[Serializable]
+public class PokerActionCommand
+{
+    public PokerActionType ActionType;
+    public int ActorNumber;
+    public int PlayerId;
+    public float Amount;
+    public string RequestedAtUtc;
+
+    public static PokerActionCommand Create(PokerActionType actionType, int actorNumber, int playerId, float amount = 0f)
+    {
+        return new PokerActionCommand
+        {
+            ActionType = actionType,
+            ActorNumber = actorNumber,
+            PlayerId = playerId,
+            Amount = amount,
+            RequestedAtUtc = DateTime.UtcNow.ToString("o")
+        };
+    }
+}
+
+public enum PokerActionType
+{
+    Fold = 0,
+    Check = 1,
+    Call = 2,
+    Raise = 3,
+    AutoFold = 4
+}

--- a/Assets/Scripts/Networking/PokerActionCommand.cs.meta
+++ b/Assets/Scripts/Networking/PokerActionCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8249648cb01e4a01bb26b967959e4e44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking/PokerAuthorityController.cs
+++ b/Assets/Scripts/Networking/PokerAuthorityController.cs
@@ -1,10 +1,16 @@
+using ExitGames.Client.Photon;
 using Photon.Pun;
 using Photon.Realtime;
 using UnityEngine;
+using System;
 
 public class PokerAuthorityController : MonoBehaviourPunCallbacks
 {
     public static PokerAuthorityController Instance { get; private set; }
+
+    public const byte ActionRequestEventCode = 41;
+    public const byte ActionResolvedEventCode = 42;
+    public const float DefaultTurnTimeoutSeconds = 15f;
 
     private PokerGameSnapshot latestSnapshot;
     public PokerGameSnapshot LatestSnapshot { get { return latestSnapshot; } }
@@ -21,6 +27,16 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
 
         Instance = this;
         psm = GetComponent<PokerStateMachine>();
+    }
+
+    private void OnEnable()
+    {
+        PhotonNetwork.NetworkingClient.EventReceived += NetworkingClient_EventReceived;
+    }
+
+    private void OnDisable()
+    {
+        PhotonNetwork.NetworkingClient.EventReceived -= NetworkingClient_EventReceived;
     }
 
     public bool HasAuthority()
@@ -71,9 +87,92 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
         Debug.Log("Published snapshot phase=" + latestSnapshot.Phase + " turnActor=" + latestSnapshot.CurrentTurnActorNumber + " pot=" + latestSnapshot.Pot);
     }
 
+    public void SubmitActionRequest(PokerActionCommand command)
+    {
+        if (command == null)
+        {
+            return;
+        }
+
+        if (!PhotonNetwork.InRoom)
+        {
+            psm.StateBetting.ReceiveNetworkAction(command);
+            return;
+        }
+
+        object[] payload = SerializeAction(command);
+        RaiseEventOptions options = new RaiseEventOptions { Receivers = ReceiverGroup.MasterClient };
+        PhotonNetwork.RaiseEvent(ActionRequestEventCode, payload, options, SendOptions.SendReliable);
+    }
+
+    public void BroadcastResolvedAction(PokerActionCommand command)
+    {
+        if (command == null)
+        {
+            return;
+        }
+
+        if (!PhotonNetwork.InRoom)
+        {
+            return;
+        }
+
+        object[] payload = SerializeAction(command);
+        RaiseEventOptions options = new RaiseEventOptions { Receivers = ReceiverGroup.All };
+        PhotonNetwork.RaiseEvent(ActionResolvedEventCode, payload, options, SendOptions.SendReliable);
+    }
+
+    private void NetworkingClient_EventReceived(EventData obj)
+    {
+        if (obj.Code == ActionRequestEventCode)
+        {
+            if (!HasAuthority())
+            {
+                return;
+            }
+
+            PokerActionCommand command = DeserializeAction(obj.CustomData as object[]);
+            psm.StateBetting.ReceiveNetworkAction(command);
+        }
+        else if (obj.Code == ActionResolvedEventCode)
+        {
+            PokerActionCommand command = DeserializeAction(obj.CustomData as object[]);
+            psm.StateBetting.OnRemoteActionResolved(command);
+        }
+    }
+
     public override void OnMasterClientSwitched(Player newMasterClient)
     {
         base.OnMasterClientSwitched(newMasterClient);
         PublishSnapshot("MasterClientSwitched");
+    }
+
+    private object[] SerializeAction(PokerActionCommand command)
+    {
+        return new object[]
+        {
+            (int)command.ActionType,
+            command.ActorNumber,
+            command.PlayerId,
+            command.Amount,
+            command.RequestedAtUtc
+        };
+    }
+
+    private PokerActionCommand DeserializeAction(object[] payload)
+    {
+        if (payload == null || payload.Length < 5)
+        {
+            return null;
+        }
+
+        return new PokerActionCommand
+        {
+            ActionType = (PokerActionType)(int)payload[0],
+            ActorNumber = (int)payload[1],
+            PlayerId = (int)payload[2],
+            Amount = Convert.ToSingle(payload[3]),
+            RequestedAtUtc = (string)payload[4]
+        };
     }
 }

--- a/Assets/Scripts/Networking/PokerAuthorityController.cs
+++ b/Assets/Scripts/Networking/PokerAuthorityController.cs
@@ -59,9 +59,14 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
         PhotonNetwork.NetworkingClient.EventReceived -= NetworkingClient_EventReceived;
     }
 
+    public bool IsOffline()
+    {
+        return !PhotonNetwork.InRoom;
+    }
+
     public bool HasAuthority()
     {
-        return !PhotonNetwork.InRoom || PhotonNetwork.IsMasterClient;
+        return IsOffline() || PhotonNetwork.IsMasterClient;
     }
 
     public bool CanControlPlayer(PokerPlayer player)
@@ -73,7 +78,7 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
 
         // Offline/single-player sessions do not have Photon ownership, so we allow
         // local control here and only enforce seat ownership once we are in a room.
-        if (!PhotonNetwork.InRoom)
+        if (IsOffline())
         {
             return true;
         }
@@ -116,7 +121,7 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
             return;
         }
 
-        if (!PhotonNetwork.InRoom)
+        if (IsOffline())
         {
             psm.StateBetting.ReceiveNetworkAction(command);
             return;
@@ -134,7 +139,7 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
             return;
         }
 
-        if (!PhotonNetwork.InRoom)
+        if (IsOffline())
         {
             return;
         }
@@ -169,6 +174,10 @@ public class PokerAuthorityController : MonoBehaviourPunCallbacks
         PublishSnapshot(SnapshotPhaseMasterClientSwitched);
     }
 
+    // For simple command payloads we serialize to an object[] of Photon-friendly values.
+    // If we later need richer data (lists, dictionaries, nested models), we should either
+    // flatten them into primitives, serialize them into a transport-safe format, or register
+    // custom Photon types if the shape becomes stable and worth formalizing.
     private object[] SerializeAction(PokerActionCommand command)
     {
         return new object[]

--- a/Assets/Scripts/Player/PokerPlayer.cs
+++ b/Assets/Scripts/Player/PokerPlayer.cs
@@ -95,6 +95,23 @@ public class PokerPlayer
         return false;
     }
 
+    public bool CommitResolvedBet(float amountDiff)
+    {
+        if (amountDiff < 0f)
+        {
+            return false;
+        }
+
+        if (playerMoney - amountDiff < 0f)
+        {
+            return false;
+        }
+
+        currBet.amount += amountDiff;
+        playerMoney -= amountDiff;
+        return true;
+    }
+
     public void ResetCurrentBet()
     {
         currBet.amount = 0;

--- a/Assets/Scripts/Poker/GameStateBetting.cs
+++ b/Assets/Scripts/Poker/GameStateBetting.cs
@@ -29,6 +29,8 @@ public class GameStateBetting : GameState
         psm.AuthorityController.PublishSnapshot(PokerAuthorityController.SnapshotPhaseBettingStarted);
     }
 
+    // Only the authority advances timeout-driven turn resolution so clients do not
+    // race each other trying to auto-resolve the same stalled turn.
     public void Tick()
     {
         if (!psm.AuthorityController.HasAuthority())
@@ -105,6 +107,8 @@ public class GameStateBetting : GameState
         actionResolvedForTurn = false;
     }
 
+    // Local UI/input still produces a Bet-like signal; this translates that into the
+    // network command model and routes it through the authority path.
     private void ReceiveLocalAction(Bet newBet)
     {
         PokerActionCommand command = TranslateBetToCommand(newBet);
@@ -123,6 +127,9 @@ public class GameStateBetting : GameState
         }
     }
 
+    // The authority is the only place where a betting command becomes real shared state.
+    // This method validates turn ownership / actor ownership, applies the result, then
+    // advances the round and broadcasts the resolved action.
     public void ReceiveNetworkAction(PokerActionCommand command)
     {
         if (!psm.AuthorityController.TryBeginAuthorityMutation(PokerAuthorityController.MutationReasonGameStateBettingReceiveNetworkAction)) { return; }
@@ -146,11 +153,7 @@ public class GameStateBetting : GameState
         nextPlayer.canInput = false;
         nextPlayer.OnPlayerEvent -= ReceiveLocalAction;
 
-        if (command.ActionType == PokerActionType.Fold || command.ActionType == PokerActionType.AutoFold)
-        {
-            // folded players stay out of the queue
-        }
-        else
+        if (command.ActionType != PokerActionType.Fold && command.ActionType != PokerActionType.AutoFold)
         {
             AddBetFromResolvedAction(actingPlayer, command);
         }
@@ -172,6 +175,9 @@ public class GameStateBetting : GameState
         }
     }
 
+    // Non-authority clients receive the already-resolved command after authority approval.
+    // For this milestone we only hook that into snapshot publication; fuller remote state
+    // rehydration/UI replay is still a later pass.
     public void OnRemoteActionResolved(PokerActionCommand command)
     {
         if (psm.AuthorityController.HasAuthority())

--- a/Assets/Scripts/Poker/GameStateBetting.cs
+++ b/Assets/Scripts/Poker/GameStateBetting.cs
@@ -1,14 +1,16 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Photon.Pun;
 
 public class GameStateBetting : GameState
 {
-
     Bet highestBet;
     public Bet HighestBet { get { return highestBet; } }
 
     PokerPlayer currPlayerBetting;
+    private float turnStartedAt = -1f;
+    private bool actionResolvedForTurn = false;
 
     public GameStateBetting(PokerStateMachine _psm) : base(_psm)
     {
@@ -25,6 +27,31 @@ public class GameStateBetting : GameState
 
         StartBetRound();
         psm.AuthorityController.PublishSnapshot("Betting.Started");
+    }
+
+    public void Tick()
+    {
+        if (!psm.AuthorityController.HasAuthority())
+        {
+            return;
+        }
+
+        if (currPlayerBetting == null || actionResolvedForTurn || turnStartedAt < 0f)
+        {
+            return;
+        }
+
+        if (Time.time - turnStartedAt < PokerAuthorityController.DefaultTurnTimeoutSeconds)
+        {
+            return;
+        }
+
+        PokerActionCommand autoFold = PokerActionCommand.Create(
+            PokerActionType.AutoFold,
+            currPlayerBetting.ActorNumber,
+            currPlayerBetting.PlayerID);
+
+        ReceiveNetworkAction(autoFold);
     }
 
     private void StartBetRound()
@@ -60,36 +87,74 @@ public class GameStateBetting : GameState
     {
         PokerPlayer nextPlayer = psm.GetNextPlayerInQueue();
         currPlayerBetting = nextPlayer;
+        actionResolvedForTurn = false;
+        turnStartedAt = Time.time;
         nextPlayer.canInput = psm.AuthorityController.CanControlPlayer(nextPlayer);
-        nextPlayer.OnPlayerEvent += ReceiveAction;
+        nextPlayer.OnPlayerEvent += ReceiveLocalAction;
         psm.AuthorityController.PublishSnapshot("Betting.WaitingForAction");
     }
-
 
     public override void ResetState()
     {
         base.ResetState();
         highestBet = new Bet(0, -1);
         currPlayerBetting = null;
+        turnStartedAt = -1f;
+        actionResolvedForTurn = false;
     }
 
-    private void ReceiveAction(Bet newBet)
+    private void ReceiveLocalAction(Bet newBet)
     {
-        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.ReceiveAction")) { return; }
-        if (psm.GetNextPlayerInQueue().PlayerID != newBet.playerID) { return; }
+        PokerActionCommand command = TranslateBetToCommand(newBet);
+        if (command == null)
+        {
+            return;
+        }
 
-        Debug.Log("Receive Action: " + newBet.amount);
+        if (psm.AuthorityController.HasAuthority())
+        {
+            ReceiveNetworkAction(command);
+        }
+        else
+        {
+            psm.AuthorityController.SubmitActionRequest(command);
+        }
+    }
+
+    public void ReceiveNetworkAction(PokerActionCommand command)
+    {
+        if (!psm.AuthorityController.TryBeginAuthorityMutation("GameStateBetting.ReceiveNetworkAction")) { return; }
+        if (command == null) { return; }
+        if (currPlayerBetting == null) { return; }
+        if (currPlayerBetting.PlayerID != command.PlayerId) { return; }
+        if (currPlayerBetting.ActorNumber != command.ActorNumber && PhotonNetwork.InRoom) { return; }
+
+        PokerPlayer actingPlayer = psm.GetPlayerWithID(command.PlayerId);
+        if (actingPlayer == null) { return; }
+
+        if (!ApplyCommand(actingPlayer, command))
+        {
+            return;
+        }
+
+        actionResolvedForTurn = true;
+        turnStartedAt = -1f;
 
         PokerPlayer nextPlayer = psm.queuePlayersInRound.Dequeue();
         nextPlayer.canInput = false;
-        nextPlayer.OnPlayerEvent -= ReceiveAction;
+        nextPlayer.OnPlayerEvent -= ReceiveLocalAction;
 
-        if (newBet.amount >= 0)
+        if (command.ActionType == PokerActionType.Fold || command.ActionType == PokerActionType.AutoFold)
         {
-            AddBet(newBet);
+            // folded players stay out of the queue
+        }
+        else
+        {
+            AddBetFromResolvedAction(actingPlayer, command);
         }
 
         psm.AuthorityController.PublishSnapshot("Betting.ActionApplied");
+        psm.AuthorityController.BroadcastResolvedAction(command);
 
         if (psm.queuePlayersInRound.Count <= 1)
         {
@@ -105,18 +170,84 @@ public class GameStateBetting : GameState
         }
     }
 
-    private void AddBet(Bet newBet)
+    public void OnRemoteActionResolved(PokerActionCommand command)
     {
-        PokerPlayer p = psm.GetPlayerWithID(newBet.playerID);
-
-        if (highestBet.playerID == -1 || highestBet.amount < p.CurrBet.amount)
+        if (psm.AuthorityController.HasAuthority())
         {
-            highestBet = p.CurrBet;
+            return;
+        }
+
+        if (command == null)
+        {
+            return;
+        }
+
+        psm.AuthorityController.PublishSnapshot("Betting.RemoteActionResolved");
+    }
+
+    private bool ApplyCommand(PokerPlayer player, PokerActionCommand command)
+    {
+        switch (command.ActionType)
+        {
+            case PokerActionType.Fold:
+            case PokerActionType.AutoFold:
+                player.SetFolded(true);
+                return true;
+            case PokerActionType.Check:
+                return Mathf.Approximately(player.CurrBet.amount, highestBet.amount);
+            case PokerActionType.Call:
+                if (command.Amount < 0f)
+                {
+                    return false;
+                }
+                player.CommitResolvedBet(command.Amount);
+                return true;
+            case PokerActionType.Raise:
+                if (command.Amount <= 0f)
+                {
+                    return false;
+                }
+                player.CommitResolvedBet(command.Amount);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void AddBetFromResolvedAction(PokerPlayer player, PokerActionCommand command)
+    {
+        if (highestBet.playerID == -1 || highestBet.amount < player.CurrBet.amount)
+        {
+            highestBet = player.CurrBet;
             Debug.Log("New highest bet of" + highestBet.amount);
         }
 
-        psm.queuePlayersInRound.Enqueue(p);
-        psm.BetManager.AddToPot(newBet.amount);
+        psm.queuePlayersInRound.Enqueue(player);
+        psm.BetManager.AddToPot(command.Amount);
+    }
+
+    private PokerActionCommand TranslateBetToCommand(Bet newBet)
+    {
+        PokerPlayer player = psm.GetPlayerWithID(newBet.playerID);
+        if (player == null)
+        {
+            return null;
+        }
+
+        if (newBet.amount < 0)
+        {
+            return PokerActionCommand.Create(PokerActionType.Fold, player.ActorNumber, player.PlayerID);
+        }
+
+        if (Mathf.Approximately(newBet.amount, 0f) && Mathf.Approximately(player.CurrBet.amount, highestBet.amount))
+        {
+            return PokerActionCommand.Create(PokerActionType.Check, player.ActorNumber, player.PlayerID, 0f);
+        }
+
+        float targetBet = player.CurrBet.amount;
+        bool isRaise = targetBet > highestBet.amount;
+        PokerActionType actionType = isRaise ? PokerActionType.Raise : PokerActionType.Call;
+        return PokerActionCommand.Create(actionType, player.ActorNumber, player.PlayerID, newBet.amount);
     }
 
     protected void GoToDealing()

--- a/Assets/Scripts/Poker/PokerStateMachine.cs
+++ b/Assets/Scripts/Poker/PokerStateMachine.cs
@@ -85,6 +85,14 @@ public class PokerStateMachine : StateMachine
         }
     }
 
+    public void Update()
+    {
+        if (stateBetting != null)
+        {
+            stateBetting.Tick();
+        }
+    }
+
     public void SetUpGame()
     {
         playersInGame = new List<PokerPlayer>();
@@ -206,7 +214,7 @@ public class PokerStateMachine : StateMachine
         List<PokerPlayer> activePlayers = new List<PokerPlayer>();
         foreach (PokerPlayer p in playersInGame)
         {
-            if (!p.IsPlayerBroke())
+            if (!p.IsPlayerBroke() && !p.IsFolded)
             {
                 activePlayers.Add(p);
             }

--- a/docs/turn-action-replication.md
+++ b/docs/turn-action-replication.md
@@ -1,0 +1,35 @@
+# Milestone 2 — Turn + Action Replication
+
+This pass builds the command path on top of the Milestone 1 authority backbone.
+
+## Added
+- `PokerActionCommand`
+  - explicit command model for `Fold`, `Check`, `Call`, `Raise`, and `AutoFold`
+- Photon event codes for:
+  - action request -> authority
+  - action resolved -> all clients
+
+## Updated
+- `PokerAuthorityController`
+  - receives command events on master client
+  - relays resolved actions to all clients
+- `GameStateBetting`
+  - translates local bets into action commands
+  - validates actor ownership and current-turn ownership on authority
+  - applies resolved commands through a single path
+  - adds turn timeout with auto-fold
+- `PokerPlayer`
+  - supports applying an authority-resolved bet delta without re-emitting local events
+- `PokerStateMachine`
+  - ticks betting timeout logic every frame
+  - excludes folded players from active-player calculations
+
+## What this milestone does now
+- clients submit action requests to authority instead of directly mutating shared state
+- authority validates turn ownership and actor ownership before applying actions
+- authority broadcasts resolved actions to all clients
+- turn timeout can auto-fold a stalled player
+- out-of-turn and wrong-seat actions are rejected at the authority layer
+
+## Current limitation / next step
+The current remote-client resolved-action handling is intentionally light: it updates snapshot publication flow, but a full remote rehydration/replay of queue/UI state from the resolved action + snapshot still needs a follow-up pass. This means the networking spine and command validation path are in place, but the last 10-20% of UX sync polish will likely be finished alongside deal/reveal sync in Milestone 3.


### PR DESCRIPTION
Builds Milestone 2 on top of the Milestone 1 authority backbone.

What changed:
- added PokerActionCommand for Fold / Check / Call / Raise / AutoFold
- added Photon event-based action request -> authority flow
- added resolved-action broadcast from authority -> all clients
- updated betting state to validate actor ownership + turn ownership on authority
- added turn timeout with basic auto-fold behavior
- added authority-resolved bet application path on PokerPlayer
- documented the pass in docs/turn-action-replication.md

Done when criteria:
- 2+ clients can progress through betting-round command flow without direct shared-state mutation from non-authority clients

Review notes:
- this PR targets the Milestone 1 branch intentionally, since it depends on that authority/snapshot work
- the command validation path is now in place, but remote-client state rehydration/UI sync is still lighter than a fully production-ready multiplayer loop
- I would treat this as the Milestone 2 backbone / first functional pass and expect at least one tightening pass after multiplayer testing.