### PR TITLE
[Athena] Start milestone 2.5 snapshot rehydration flow

### DIFF
--- a/Assets/Scripts/Networking/PokerGameSnapshot.cs
+++ b/Assets/Scripts/Networking/PokerGameSnapshot.cs
@@ -116,6 +116,27 @@ public class CardSnapshot
         };
     }
 
+    public Card ToCard()
+    {
+        if (IsHidden)
+        {
+            return null;
+        }
+
+        SUIT parsedSuit;
+        VALUE parsedValue;
+        if (!Enum.TryParse(Suit, out parsedSuit) || !Enum.TryParse(Value, out parsedValue))
+        {
+            return null;
+        }
+
+        return new Card
+        {
+            MyValue = parsedValue,
+            MySuit = parsedSuit
+        };
+    }
+
     public static CardSnapshot Hidden()
     {
         return new CardSnapshot

--- a/Assets/Scripts/Player/PlayerObject.cs
+++ b/Assets/Scripts/Player/PlayerObject.cs
@@ -33,7 +33,36 @@ public class PlayerObject : MonoBehaviour
     public void CreateCards()
     {
         List<Card> cardsInHand = psm.GetPlayerWithID(playerNum).PlayerHand.DealtHand;
+        CreateCardsFromList(cardsInHand);
+    }
 
+    public void ApplySnapshotCards(List<CardSnapshot> cardSnapshots)
+    {
+        ClearCards();
+        if (cardSnapshots == null)
+        {
+            return;
+        }
+
+        foreach (CardSnapshot snapshot in cardSnapshots)
+        {
+            GameObject spawnedCard = Instantiate(psm.cardPrefab);
+            spawnedCard.transform.parent = cardHandTransform;
+            CardObject cardObject = spawnedCard.GetComponent<CardObject>();
+
+            Card card = snapshot.ToCard();
+            if (card == null)
+            {
+                card = new Card { MySuit = SUIT.H, MyValue = VALUE.VA };
+            }
+
+            cardObject.SetCard(card);
+            cardObject.SetFaceUp(!snapshot.IsHidden);
+        }
+    }
+
+    private void CreateCardsFromList(List<Card> cardsInHand)
+    {
         foreach (Card c in cardsInHand)
         {
             GameObject spawnedCard = Instantiate(psm.cardPrefab);

--- a/Assets/Scripts/Player/PokerPlayer.cs
+++ b/Assets/Scripts/Player/PokerPlayer.cs
@@ -112,6 +112,20 @@ public class PokerPlayer
         return true;
     }
 
+    public void ApplySnapshotState(PlayerSnapshot snapshot)
+    {
+        if (snapshot == null)
+        {
+            return;
+        }
+
+        ActorNumber = snapshot.ActorNumber;
+        DisplayName = snapshot.DisplayName;
+        playerMoney = snapshot.Chips;
+        currBet.amount = snapshot.CurrentBet;
+        isFolded = snapshot.Folded;
+    }
+
     public void ResetCurrentBet()
     {
         currBet.amount = 0;
@@ -120,6 +134,11 @@ public class PokerPlayer
     public void AddMoney(float _amount)
     {
         playerMoney += _amount;
+    }
+
+    public void SetCanInput(bool value)
+    {
+        canInput = value;
     }
 
     public bool IsPlayerBroke() { return playerMoney <= 0; }

--- a/Assets/Scripts/Poker/PokerStateMachine.cs
+++ b/Assets/Scripts/Poker/PokerStateMachine.cs
@@ -34,6 +34,7 @@ public class PokerStateMachine : StateMachine
     public GenHand riverHand;
 
     GameObject riverHandGameObject;
+    private string lastAppliedSnapshotAtUtc;
 
     private BettingManager betManager;
     public BettingManager BetManager { get { return betManager; } }
@@ -91,6 +92,11 @@ public class PokerStateMachine : StateMachine
         {
             stateBetting.Tick();
         }
+
+        if (!authorityController.HasAuthority())
+        {
+            ApplyLatestAuthoritativeSnapshot();
+        }
     }
 
     public void SetUpGame()
@@ -108,6 +114,7 @@ public class PokerStateMachine : StateMachine
         MapPhotonPlayersToSeats();
 
         queuePlayersInRound = new Queue<PokerPlayer>();
+        lastAppliedSnapshotAtUtc = null;
 
         betManager = new BettingManager(this);
 
@@ -136,6 +143,7 @@ public class PokerStateMachine : StateMachine
 
         betManager.NewRound();
         stateDeal.NewRound();
+        lastAppliedSnapshotAtUtc = null;
         DestroyAllVisuals();
         StartRound();
     }
@@ -308,5 +316,148 @@ public class PokerStateMachine : StateMachine
     {
         PokerPlayer dealer = BetManager.SmallBlindPlayer;
         return dealer != null ? dealer.ActorNumber : -1;
+    }
+
+    // Milestone 2.5 starts here: non-authority clients consume the latest authoritative
+    // snapshot as real state input so remote tables stop depending on local inference.
+    public void ApplyLatestAuthoritativeSnapshot()
+    {
+        PokerGameSnapshot snapshot = authorityController != null ? authorityController.LatestSnapshot : null;
+        if (snapshot == null)
+        {
+            return;
+        }
+
+        if (lastAppliedSnapshotAtUtc == snapshot.UpdatedAtUtc)
+        {
+            return;
+        }
+
+        ApplySnapshot(snapshot);
+        lastAppliedSnapshotAtUtc = snapshot.UpdatedAtUtc;
+    }
+
+    public void ApplySnapshot(PokerGameSnapshot snapshot)
+    {
+        if (snapshot == null || snapshot.Players == null)
+        {
+            return;
+        }
+
+        Debug.Log("Applying authoritative snapshot phase=" + snapshot.Phase + " updatedAt=" + snapshot.UpdatedAtUtc + " turnActor=" + snapshot.CurrentTurnActorNumber);
+
+        ApplyPlayerSnapshots(snapshot.Players, snapshot.CurrentTurnActorNumber);
+        ApplyCommunityCardSnapshot(snapshot);
+        SyncQueueToSnapshot(snapshot);
+        RefreshPlayerHandVisuals(snapshot.Players);
+    }
+
+    private void ApplyPlayerSnapshots(List<PlayerSnapshot> playerSnapshots, int currentTurnActorNumber)
+    {
+        foreach (PlayerSnapshot snapshot in playerSnapshots)
+        {
+            PokerPlayer player = GetPlayerWithID(snapshot.SeatIndex);
+            if (player == null)
+            {
+                continue;
+            }
+
+            player.ApplySnapshotState(snapshot);
+            player.SetCanInput(snapshot.ActorNumber == GetCurrentLocalActorNumber() && snapshot.ActorNumber == currentTurnActorNumber);
+        }
+    }
+
+    private void ApplyCommunityCardSnapshot(PokerGameSnapshot snapshot)
+    {
+        if (riverHand == null)
+        {
+            riverHand = new GenHand();
+        }
+
+        riverHand.ClearHand();
+        if (snapshot.CommunityCards != null)
+        {
+            foreach (CardSnapshot card in snapshot.CommunityCards)
+            {
+                Card rebuiltCard = card.ToCard();
+                if (rebuiltCard != null)
+                {
+                    riverHand.DealCard(rebuiltCard);
+                }
+            }
+        }
+
+        if (snapshot.CommunityCardCount > 0)
+        {
+            CreateRiverHandVisual();
+        }
+        else if (riverHandGameObject != null)
+        {
+            RiverObject riverObject = riverHandGameObject.GetComponent<RiverObject>();
+            if (riverObject != null)
+            {
+                riverObject.ClearCards();
+            }
+        }
+    }
+
+    private void SyncQueueToSnapshot(PokerGameSnapshot snapshot)
+    {
+        if (queuePlayersInRound == null)
+        {
+            queuePlayersInRound = new Queue<PokerPlayer>();
+        }
+
+        queuePlayersInRound.Clear();
+        foreach (PokerPlayer player in playersInGame)
+        {
+            if (!player.IsFolded && !player.IsPlayerBroke())
+            {
+                queuePlayersInRound.Enqueue(player);
+            }
+        }
+
+        if (snapshot.CurrentTurnActorNumber == -1 || queuePlayersInRound.Count == 0)
+        {
+            return;
+        }
+
+        int safety = queuePlayersInRound.Count;
+        while (queuePlayersInRound.Count > 0 && queuePlayersInRound.Peek().ActorNumber != snapshot.CurrentTurnActorNumber && safety-- > 0)
+        {
+            SendNextToBackOfQueue();
+        }
+    }
+
+    private void RefreshPlayerHandVisuals(List<PlayerSnapshot> playerSnapshots)
+    {
+        if (PokerHandsTransform == null)
+        {
+            return;
+        }
+
+        Dictionary<int, PlayerSnapshot> snapshotBySeat = playerSnapshots.ToDictionary(snapshot => snapshot.SeatIndex, snapshot => snapshot);
+        foreach (Transform child in PokerHandsTransform)
+        {
+            PlayerObject playerObject = child.GetComponent<PlayerObject>();
+            if (playerObject == null || playerObject.Player == null)
+            {
+                continue;
+            }
+
+            PlayerSnapshot snapshot;
+            if (!snapshotBySeat.TryGetValue(playerObject.Player.PlayerID, out snapshot))
+            {
+                continue;
+            }
+
+            playerObject.SetHand(playerObject.Player);
+            playerObject.ApplySnapshotCards(snapshot.HoleCards);
+        }
+    }
+
+    private int GetCurrentLocalActorNumber()
+    {
+        return PhotonNetwork.LocalPlayer != null ? PhotonNetwork.LocalPlayer.ActorNumber : -1;
     }
 }

--- a/docs/multiplayer-mvp-milestones.md
+++ b/docs/multiplayer-mvp-milestones.md
@@ -79,6 +79,52 @@ Done when:
 
 ---
 
+## Milestone 2.5 — Snapshot Rehydration + Remote Table Sync
+
+Purpose: make non-authority clients rebuild a coherent table state from authority-approved data so Milestone 3 can focus on cards/reveal logic instead of basic sync repair.
+
+Tasks:
+- Apply `PokerGameSnapshot` on non-authority clients as real input, not just logging/debug state
+- Rehydrate shared table state from snapshot data:
+  - phase
+  - dealer/blinds
+  - current turn actor
+  - pot
+  - highest bet
+  - folded/all-in flags
+  - player chip counts/current bets
+- Keep seat-to-actor mapping and display names consistent after snapshot apply
+- Refresh gameplay UI from authoritative state after every accepted action:
+  - whose turn
+  - call amount / highest bet
+  - pot
+  - chip totals
+  - folded markers
+  - latest action / status text
+- Drive card presentation rules from snapshot state:
+  - local player sees own hole cards
+  - opponents remain hidden until allowed
+  - community card visibility/count matches authority state
+- Make resolved actions visibly update remote clients without relying on local guesswork
+- Add a late-join / reconnect bootstrap path where a client can apply the latest snapshot and land in a coherent mid-hand state
+- Keep snapshot application separate from optional visual animation polish
+
+Done when:
+- A non-authority client can join or rejoin mid-hand, apply the latest snapshot, and render a coherent table state.
+- Remote clients stay visually consistent with authority after accepted actions.
+- Milestone 3 can build on snapshot-driven rendering instead of bespoke per-case sync logic.
+
+Implementation plan:
+1. Add a client-side `ApplySnapshot(...)` entry point in the game state layer so non-authority clients can consume `PokerGameSnapshot` as real gameplay input.
+2. Rehydrate player runtime state from snapshot data (chips, current bet, folded/all-in, actor mapping, display names) without breaking local ownership rules.
+3. Rebuild turn/pot/highest-bet state from snapshot data so remote clients stop relying on local inference after resolved actions.
+4. Refresh table visuals and gameplay UI from snapshot application, including turn indicator, visible community cards, and hidden vs visible hole-card rules.
+5. Make resolved-action events trigger snapshot-driven remote updates instead of lightweight placeholder behavior.
+6. Add a bootstrap/reconnect path so a joining client can receive/apply the latest snapshot and land in a coherent mid-hand state.
+7. Add debug logging / sanity checks for snapshot mismatches so desyncs are easier to spot before Milestone 3 work begins.
+
+---
+
 ## Milestone 3 — Deal/Reveal Sync + Winner Resolution
 
 Purpose: ensure every client sees consistent cards and outcomes.


### PR DESCRIPTION
Starts Milestone 2.5 on top of the Milestone 2 branch.

What changed:
- added a concrete implementation plan to the milestone doc
- added initial snapshot application on non-authority clients
- rehydrates player runtime state from snapshot data
- rehydrates turn/input ownership from snapshot data
- rebuilds queue order from current turn actor
- rebuilds community cards from snapshot data
- refreshes player hand visuals from hole-card snapshot data
- avoids reapplying the same snapshot every frame by tracking UpdatedAtUtc

Review notes:
- this is the first slice of Milestone 2.5, not the full pass
- reconnect/bootstrap and fuller table/UI sync still need follow-up
- PR intentionally targets the Milestone 2 branch line because main does not yet contain Milestone 2