### PR TITLE
[Athena] Break down milestone 4 and add table status plumbing

### DIFF
--- a/Assets/Scripts/Player/PokerPlayer.cs
+++ b/Assets/Scripts/Player/PokerPlayer.cs
@@ -125,7 +125,14 @@ public class PokerPlayer
         }
 
         ActorNumber = snapshot.ActorNumber;
-        DisplayName = snapshot.DisplayName;
+        if (string.IsNullOrEmpty(snapshot.DisplayName))
+        {
+            DisplayName = snapshot.ActorNumber > 0 ? "Player " + snapshot.ActorNumber : "Seat " + playerID;
+        }
+        else
+        {
+            DisplayName = snapshot.DisplayName;
+        }
         playerMoney = snapshot.Chips;
         currBet.amount = snapshot.CurrentBet;
         isFolded = snapshot.Folded;

--- a/Assets/Scripts/UI/UI_RoundManager.cs
+++ b/Assets/Scripts/UI/UI_RoundManager.cs
@@ -8,12 +8,15 @@ public class UI_RoundManager : MonoBehaviour
     PokerStateMachine psm;
 
     public GameObject RoundOver;
+    public UI_Text TableStatusText;
     private UI_Text roundEndText;
+    private string lastStatusMessage;
 
     private void Awake()
     {
         roundEndText = RoundOver.GetComponentInChildren<UI_Text>();
         RoundOver.SetActive(false);
+        SetTableStatus("Waiting for table state...");
     }
 
     private void Start()
@@ -22,13 +25,119 @@ public class UI_RoundManager : MonoBehaviour
         psm.StateRoundEnd.OnStateStart += ShowRoundEnd;
         psm.StateRoundEnd.OnStateEnd += HideRoundEnd;
         psm.OnRoundResultSnapshotApplied += ShowRoundResultFromSnapshot;
+        psm.OnSnapshotApplied += RefreshTableStatusFromSnapshot;
+        RefreshLocalTableStatus();
     }
 
     private void OnDisable()
     {
+        if (psm == null)
+        {
+            return;
+        }
+
         psm.StateRoundEnd.OnStateStart -= ShowRoundEnd;
         psm.StateRoundEnd.OnStateEnd -= HideRoundEnd;
         psm.OnRoundResultSnapshotApplied -= ShowRoundResultFromSnapshot;
+        psm.OnSnapshotApplied -= RefreshTableStatusFromSnapshot;
+    }
+
+
+    private void RefreshLocalTableStatus()
+    {
+        if (psm == null)
+        {
+            return;
+        }
+
+        string currentTurn = GetCurrentTurnDisplayName();
+        float highestBet = psm.HighestBet.amount;
+        float callAmount = 0f;
+        PokerPlayer localPlayer = psm.GetPlayerForLocalClient();
+        if (localPlayer != null)
+        {
+            callAmount = Mathf.Max(0f, highestBet - localPlayer.CurrBet.amount);
+        }
+
+        string status = "Turn: " + currentTurn
+            + "\nPot: " + psm.BetManager.PotAmount
+            + "\nCall: " + callAmount
+            + "\nHighest Bet: " + highestBet;
+        SetTableStatus(status);
+    }
+
+    private void RefreshTableStatusFromSnapshot(PokerGameSnapshot snapshot)
+    {
+        if (snapshot == null)
+        {
+            return;
+        }
+
+        string turnName = GetSnapshotTurnDisplayName(snapshot);
+        float localCurrentBet = 0f;
+        PlayerSnapshot localSnapshot = snapshot.Players != null ? snapshot.Players.Find(player => player.IsLocalPlayer) : null;
+        if (localSnapshot != null)
+        {
+            localCurrentBet = localSnapshot.CurrentBet;
+        }
+
+        float callAmount = Mathf.Max(0f, snapshot.HighestBet - localCurrentBet);
+        string status = "Turn: " + turnName
+            + "\nPot: " + snapshot.Pot
+            + "\nCall: " + callAmount
+            + "\nHighest Bet: " + snapshot.HighestBet;
+
+        if (snapshot.ShowdownResolved && !string.IsNullOrEmpty(snapshot.WinningMessage))
+        {
+            status += "\nLast Action: " + snapshot.WinningMessage;
+        }
+        else if (!string.IsNullOrEmpty(snapshot.Phase))
+        {
+            status += "\nPhase: " + snapshot.Phase;
+        }
+
+        SetTableStatus(status);
+    }
+
+    private string GetCurrentTurnDisplayName()
+    {
+        if (psm == null)
+        {
+            return "Waiting";
+        }
+
+        int actorNumber = psm.GetCurrentTurnActorNumber();
+        PokerPlayer currentPlayer = psm.PlayersInGame.Find(player => player.ActorNumber == actorNumber);
+        return currentPlayer != null ? currentPlayer.DisplayName : "Waiting";
+    }
+
+    private string GetSnapshotTurnDisplayName(PokerGameSnapshot snapshot)
+    {
+        if (snapshot == null || snapshot.Players == null)
+        {
+            return "Waiting";
+        }
+
+        PlayerSnapshot currentPlayer = snapshot.Players.Find(player => player.ActorNumber == snapshot.CurrentTurnActorNumber);
+        if (currentPlayer == null)
+        {
+            return snapshot.ShowdownResolved ? "Round complete" : "Waiting";
+        }
+
+        return string.IsNullOrEmpty(currentPlayer.DisplayName) ? "Player " + currentPlayer.ActorNumber : currentPlayer.DisplayName;
+    }
+
+    private void SetTableStatus(string status)
+    {
+        lastStatusMessage = status;
+        if (TableStatusText != null)
+        {
+            TableStatusText.SetText(status);
+        }
+        else
+        {
+            Debug.Log("TableStatus: " + status.Replace("\n", " | "));
+        }
     }
 
     private void ShowRoundEnd()

--- a/docs/milestone-4-breakdown.md
+++ b/docs/milestone-4-breakdown.md
@@ -1,0 +1,122 @@
+# Milestone 4 Breakdown — Room-to-Table UX Glue
+
+Milestone 4 is the bridge between a technically synced poker prototype and a multiplayer loop that actually feels playable.
+
+## Goal
+
+Get the game from **room/lobby setup → table start → hand end → next hand** with enough clarity that friends can play multiple hands without getting confused or stuck.
+
+---
+
+## The 3 Task Buckets
+
+### 1. Room → Table Start Flow
+
+**Goal:** make the transition from lobby room to active table deterministic and understandable.
+
+**Includes:**
+- Ready/start gate remains authoritative
+- Room only starts when the right players are ready
+- Table scene starts with seats mapped to real players
+- Display names carry over cleanly from Photon room to table
+
+**Athena can do:**
+- Document the expected flow and ownership rules
+- Audit existing ready/start code for gaps
+- Tighten seat/display-name behavior in code where data already exists
+- Add defensive logic for missing names / empty seats
+
+**Drew likely needs to do:**
+- Unity scene wiring / inspector hookups if UI objects are missing
+- Any desired layout decisions for how seat/name presentation should look visually
+- Manual multiplayer playtesting to confirm the start flow feels right
+
+**Success looks like:**
+- Players ready up in the room
+- Master starts the game
+- Everyone lands at the table with correct seat ownership and names
+
+---
+
+### 2. In-Game Table Status + Clarity
+
+**Goal:** make it obvious what is happening during play.
+
+**Includes:**
+- Whose turn it is
+- Current pot
+- Call amount / highest bet
+- Last action / latest meaningful status text
+- Basic player/table context that reduces confusion
+
+**Athena can do:**
+- Add a lightweight status model / helper methods in gameplay code
+- Add event hooks so UI can render authoritative state changes
+- Update existing UI manager scripts to display status text when the references already exist
+- Document what UI fields need to exist if they are not wired yet
+
+**Drew likely needs to do:**
+- Hook TMP/UI references in Unity if the scene does not already expose them
+- Decide where status text should live visually on the table
+- Adjust polish/layout/fonts/anchoring so it actually looks good
+
+**Success looks like:**
+- A remote player can glance at the table and understand the current hand state without guessing
+
+---
+
+### 3. End-of-Hand → Next-Hand Loop
+
+**Goal:** make the table continue into the next hand smoothly instead of feeling like a dead-end prototype.
+
+**Includes:**
+- End-of-hand state is shown clearly
+- Round resolution leads back into the next hand cleanly
+- No confusing stall after showdown / payout
+- Minimal repeated-hand loop works for private-room MVP play
+
+**Athena can do:**
+- Define the state transition plan
+- Add code support for a basic replay/continue loop where the logic already exists
+- Add guard rails around round-end UI visibility and restart flow
+- Document what still needs manual Unity hookup or playtest verification
+
+**Drew likely needs to do:**
+- Decide whether next-hand progression is automatic or button-driven
+- Wire any restart/continue button in the scene if needed
+- Playtest pacing and UX feel in-editor / with another client
+
+**Success looks like:**
+- Hand ends
+- Players understand the result
+- Game can move into the next hand without weird dead air or manual dev intervention
+
+---
+
+## What Athena can implement right now
+
+These are the parts that are mostly code-side and do not obviously require new art/layout work:
+
+1. **Document Milestone 4 clearly**
+2. **Add a table-status snapshot/helper layer** for UI consumption
+3. **Improve seat/display-name fallback behavior**
+4. **Add clearer round/turn status plumbing in code**
+5. **Add a documented checklist of Unity-side hookups Drew still needs to verify**
+
+## What probably still needs Drew
+
+1. **Unity inspector hookups** for any new text fields/buttons
+2. **Visual/layout decisions** for where status text and seat labels should live
+3. **Multiplayer feel testing** with real clients
+4. **Final product decisions** like automatic next-hand start vs button-driven continue
+
+---
+
+## Recommended implementation order
+
+1. **Seat + display-name clarity**
+2. **Status text / table clarity**
+3. **Next-hand loop glue**
+4. **Manual Unity hookup + multiplayer playtest**
+
+That order keeps the work honest: first make the table understandable, then make it loop.


### PR DESCRIPTION
## Summary
- add a milestone 4 breakdown doc covering room-to-table flow, table clarity, and next-hand loop work
- add basic table status plumbing to `UI_RoundManager` for turn, pot, call amount, highest bet, and phase/last action
- add display-name fallback behavior when snapshot data is missing a player name

## Notes
- `TableStatusText` still needs to be wired in the Unity inspector if you want the status visible on-screen
- if that reference is not wired yet, the status falls back to debug logging instead of breaking

## Testing
- not run in Unity editor
- code-side implementation only; scene wiring and multiplayer feel should be verified manually